### PR TITLE
Fixes unity script compile error 'TypeLoadException'

### DIFF
--- a/plugin/Assets/PlayServicesResolver/Editor/PlayServicesResolver.cs
+++ b/plugin/Assets/PlayServicesResolver/Editor/PlayServicesResolver.cs
@@ -93,9 +93,7 @@ namespace GooglePlayServices
                 if (_resolver == null)
                 {
                     // create the latest resolver known.
-                    Type type = Type.GetType(CurrentResolverName, true);
-
-                    _resolver = Activator.CreateInstance(type) as IResolver;
+                    _resolver = Activator.CreateInstance("GooglePlayServices", CurrentResolverName) as IResolver;
                 }
                 return _resolver;
             }


### PR DESCRIPTION
Existing code:
`Type type = Type.GetType(CurrentResolverName, true);`
Can produce an error in the editor "TypeLoadException: Could not load type ResolverVer1_1."

Adjusting the code to use the AssemblyName "GooglePlayServices" fixes the issue.