### PR TITLE
Fix for issue #20

### DIFF
--- a/source/VersionHandler/src/VersionHandler.cs
+++ b/source/VersionHandler/src/VersionHandler.cs
@@ -136,7 +136,15 @@ public class VersionHandler : AssetPostprocessor {
         static HashSet<BuildTarget> GetBlackList() {
             if (targetBlackList == null) {
                 targetBlackList = new HashSet<BuildTarget>();
-                if (GetUnityVersionMajorMinor() >= 5.5) {
+                var unityVersion = GetUnityVersionMajorMinor();
+                if (unityVersion < 5.2) {
+                    targetBlackList.Add(BuildTarget.Nintendo3DS);
+                    targetBlackList.Add(BuildTarget.WiiU);
+                }
+                if (unityVersion < 5.3) {
+                    targetBlackList.Add(BuildTarget.tvOS);
+                }
+                if (unityVersion >= 5.5) {
                     targetBlackList.Add(BuildTarget.PS3);
                     targetBlackList.Add(BuildTarget.XBOX360);
                 }


### PR DESCRIPTION
Fixes [Issue #20](https://github.com/googlesamples/unity-jar-resolver/issues/20).

Added unsupported BuildTargets to blacklist for Unity 5.0, 5.1 and 5.2.
