### PR TITLE
Put dependencies in a distinguishable folder

### DIFF
--- a/source/PlayServicesResolver/src/PlayServicesResolver.cs
+++ b/source/PlayServicesResolver/src/PlayServicesResolver.cs
@@ -248,7 +248,7 @@ namespace GooglePlayServices
         private static void Resolve(System.Action resolutionComplete = null)
         {
             DeleteFiles(Resolver.OnBundleId(PlayerSettings.bundleIdentifier));
-            Resolver.DoResolution(svcSupport, "Assets/Plugins/Android",
+            Resolver.DoResolution(svcSupport, "Assets/Plugins/UnityJarResolver/Android",
                                   HandleOverwriteConfirmation,
                                   () => {
                                       AssetDatabase.Refresh();


### PR DESCRIPTION
This way it is easier to do clean-ups in no longer needed dependencies
and unity-jar-resolver copied dependencies stay separately from manually
placed Android native libraries.