### PR TITLE
Fix SDK path in PlayServicesSupport

### DIFF
--- a/source/JarResolverLib/src/Google.JarResolver/PlayServicesSupport.cs
+++ b/source/JarResolverLib/src/Google.JarResolver/PlayServicesSupport.cs
@@ -97,7 +97,7 @@ namespace Google.JarResolver
         {
             get
             {
-                if (sdk == null)
+                if (string.IsNullOrEmpty(sdk))
                 {
                     sdk = System.Environment.GetEnvironmentVariable("ANDROID_HOME");
                 }


### PR DESCRIPTION
EditorPrefs return empty string for missing keys, so the check in the
property misses this case. This causes build problems on CI environments
where there's no user setting for SDK path.