### PR TITLE
Check if Editor JdkPath setting is null or empty

### DIFF
--- a/source/PlayServicesResolver/src/DefaultResolver.cs
+++ b/source/PlayServicesResolver/src/DefaultResolver.cs
@@ -216,7 +216,10 @@ namespace GooglePlayServices
         private string FindJavaTool(string javaTool)
         {
             string javaHome = UnityEditor.EditorPrefs.GetString("JdkPath");
-            javaHome = javaHome ?? Environment.GetEnvironmentVariable("JAVA_HOME");
+            if (string.IsNullOrEmpty(javaHome))
+            {
+                javaHome = Environment.GetEnvironmentVariable("JAVA_HOME");
+            }
             string toolPath;
             if (javaHome != null)
             {


### PR DESCRIPTION
Editor settings doesn't return null if the JDK path is not set, but an empty string.