### PR TITLE
Turning off auto resolution now prevents several methods from running in the background when they should now have been

### DIFF
--- a/source/PlayServicesResolver/src/PlayServicesResolver.cs
+++ b/source/PlayServicesResolver/src/PlayServicesResolver.cs
@@ -641,19 +641,34 @@ namespace GooglePlayServices
                 AndroidSdkRootChanged += ResolveOnAndroidSdkRootChange;
                 ScheduleAutoResolve();
             }
-
-            // Register events to monitor build system changes for the Android Resolver and other
-            // plugins.
-            RunOnMainThread.OnUpdate += PollBundleId;
-            RunOnMainThread.OnUpdate += PollBuildSystem;
-            RunOnMainThread.OnUpdate += PollAndroidAbis;
-            RunOnMainThread.OnUpdate += PollAndroidSdkRoot;
+			
+			if (GooglePlayServices.SettingsDialog.EnableAutoResolution)
+				LinkAutoResolution();
         }
 
-        /// <summary>
-        /// Called from PlayServicesSupport to log a message.
-        /// </summary>
-        internal static void LogDelegate(string message, PlayServicesSupport.LogLevel level) {
+		public static void UnlinkAutoResolution() {
+			// Unregister events to monitor build system changes for the Android Resolver and other
+			// plugins.
+			RunOnMainThread.OnUpdate -= PollBundleId;
+			RunOnMainThread.OnUpdate -= PollBuildSystem;
+			RunOnMainThread.OnUpdate -= PollAndroidAbis;
+			RunOnMainThread.OnUpdate -= PollAndroidSdkRoot;
+		}
+
+		public static void LinkAutoResolution() {
+			// Register events to monitor build system changes for the Android Resolver and other
+			// plugins.
+			UnlinkAutoResolution();
+			RunOnMainThread.OnUpdate += PollBundleId;
+			RunOnMainThread.OnUpdate += PollBuildSystem;
+			RunOnMainThread.OnUpdate += PollAndroidAbis;
+			RunOnMainThread.OnUpdate += PollAndroidSdkRoot;
+		}
+
+		/// <summary>
+		/// Called from PlayServicesSupport to log a message.
+		/// </summary>
+		internal static void LogDelegate(string message, PlayServicesSupport.LogLevel level) {
             Google.LogLevel loggerLogLevel = Google.LogLevel.Info;
             switch (level) {
                 case PlayServicesSupport.LogLevel.Info:

--- a/source/PlayServicesResolver/src/SettingsDialog.cs
+++ b/source/PlayServicesResolver/src/SettingsDialog.cs
@@ -117,9 +117,17 @@ namespace GooglePlayServices
         }
 
         internal static bool EnableAutoResolution {
-            set { projectSettings.SetBool(AutoResolveKey, value); }
-            get { return projectSettings.GetBool(AutoResolveKey, true); }
-        }
+			set
+			{
+				projectSettings.SetBool(AutoResolveKey, value);
+
+				if (value)
+					PlayServicesResolver.LinkAutoResolution();
+				else
+					PlayServicesResolver.UnlinkAutoResolution();
+			}
+			get { return projectSettings.GetBool(AutoResolveKey, true); }
+		}
 
         internal static bool UseGradleDaemon {
             private set { projectSettings.SetBool(UseGradleDaemonKey, value); }


### PR DESCRIPTION
Methods that used to be hooked into the editor update tick are now able to be unhooked and will not automatically be assigned via the PlayServicesResolver's static constructor if auto resolution is turned off in the settings