### PR TITLE
Properly reference java tool name in log

### DIFF
--- a/source/PlayServicesResolver/src/JavaUtilities.cs
+++ b/source/PlayServicesResolver/src/JavaUtilities.cs
@@ -124,7 +124,7 @@ namespace GooglePlayServices {
                         "Android Resolver",
                         String.Format("{0} environment references a directory ({1}) that does " +
                                       "not contain {2} which is required to process Android " +
-                                      "libraries.", JAVA_HOME, javaHome, toolPath),
+                                      "libraries.", JAVA_HOME, javaHome, javaTool),
                         "OK");
                     throw new ToolNotFoundException(
                         String.Format("{0} not found, {1} references incomplete Java distribution.",


### PR DESCRIPTION
The ToolNotFoundException contains the right reference but the Unity Editor log contained the unresolved path, an empty string.