### PR TITLE
Add 30 second delay before starting auto-resolution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version TBD
+## New Features
+* Android Resolver: Auto-resolution now displays a window for a few seconds
+  allowing the user to skip the resolution process.  The delay time can be
+  configured via the settings menu.
+
 # Version 1.2.116 - Jun 7, 2019
 ## Bug Fixes
 * Android Resolver: Fixed resolution of Android dependencies without version

--- a/source/PlayServicesResolver/src/PlayServicesResolver.cs
+++ b/source/PlayServicesResolver/src/PlayServicesResolver.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PlayServicesResolver.cs" company="Google Inc.">
+// <copyright file="PlayServicesResolver.cs" company="Google Inc.">
 // Copyright (C) 2015 Google Inc. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -149,14 +149,12 @@ namespace GooglePlayServices {
                                 return true;
                             } else if (elementName == "package" &&
                                        parentElementName == "packages") {
-                                if (isStart && reader.Read() &&
-                                    reader.NodeType == XmlNodeType.Text) {
+                                if (reader.Read() && reader.NodeType == XmlNodeType.Text) {
                                     packages.Add(reader.ReadContentAsString());
                                 }
                                 return true;
                             } else if (elementName == "file" && parentElementName == "files") {
-                                if (isStart && reader.Read() &&
-                                    reader.NodeType == XmlNodeType.Text) {
+                                if (reader.Read() && reader.NodeType == XmlNodeType.Text) {
                                     files.Add(reader.ReadContentAsString());
                                 }
                                 return true;
@@ -980,32 +978,70 @@ namespace GooglePlayServices {
         /// Defaults to 1 second.</param>
         private static void ScheduleAutoResolve(double delayInMilliseconds = 1000.0) {
             lock (typeof(PlayServicesResolver)) {
-                if (!autoResolving) {
-                    RunOnMainThread.Cancel(autoResolveJobId);
-                    autoResolveJobId = RunOnMainThread.Schedule(
-                        () => {
-                            lock (typeof(PlayServicesResolver)) {
-                                autoResolving = true;
-                            }
-                            RunOnMainThread.PollOnUpdateUntilComplete(() => {
-                                if (EditorApplication.isCompiling) return false;
-                                // Only run AutoResolve() if we have a valid autoResolveJobId.
-                                // If autoResolveJobId is 0, ScheduleResolve()
-                                // has already been run and we should not run AutoResolve()
-                                // again.
-                                if (autoResolveJobId != 0) {
-                                    AutoResolve(() => {
-                                        lock (typeof(PlayServicesResolver)) {
-                                            autoResolving = false;
-                                            autoResolveJobId = 0;
-                                        }
-                                    });
-                                }
-                                return true;
-                            });
-                        },
-                        delayInMilliseconds);
+                if (autoResolving) {
+                    return;
                 }
+
+                RunOnMainThread.Cancel(autoResolveJobId);
+                autoResolveJobId = RunOnMainThread.Schedule(() => {
+                    lock (typeof(PlayServicesResolver)) {
+                        autoResolving = true;
+                    }
+
+                    int delaySec = GooglePlayServices.SettingsDialog.AutoResolutionDelay;
+                    DateTimeOffset resolveTime = DateTimeOffset.Now.AddSeconds(delaySec);
+                    bool shouldResolve = true;
+                    AlertModal alert = null;
+                    RunOnMainThread.PollOnUpdateUntilComplete(() => {
+                        if (resolveTime > DateTimeOffset.Now &&
+                            Resolver.AutomaticResolutionEnabled()) {
+                            int countDown = (int)(resolveTime - DateTimeOffset.Now).TotalSeconds;
+                            string message = String.Format("Auto Resolve Dependencies in {0}s",
+                                                           countDown);
+                            if (alert == null) {
+                                alert = new AlertModal {
+                                    Title = "Android Resolver: Resolve or skip resolution?",
+                                    Message = message,
+                                    Ok = new AlertModal.LabeledAction {
+                                        Label = "Resolve",
+                                        DelegateAction = () => {
+                                            resolveTime = DateTimeOffset.Now;
+                                            shouldResolve = true;
+                                        }
+                                    },
+                                    Cancel = new AlertModal.LabeledAction {
+                                        Label = "Skip",
+                                        DelegateAction = () => {
+                                            resolveTime = DateTimeOffset.Now;
+                                            shouldResolve = false;
+                                        }
+                                    }
+                                };
+                                alert.Display();
+                            }
+                            if (alert != null) {
+                                alert.Message = message;
+                                return false;
+                            }
+                        }
+
+                        if (EditorApplication.isCompiling) return false;
+                        // Only run AutoResolve() if we have a valid autoResolveJobId.
+                        // If autoResolveJobId is 0, ScheduleResolve()
+                        // has already been run and we should not run AutoResolve()
+                        // again.
+
+                        if (shouldResolve && autoResolveJobId != 0) {
+                            AutoResolve(() => {
+                                lock (typeof(PlayServicesResolver)) {
+                                    autoResolving = false;
+                                    autoResolveJobId = 0;
+                                }
+                            });
+                        }
+                        return true;
+                    });
+                }, delayInMilliseconds);
             }
         }
 
@@ -1457,9 +1493,7 @@ namespace GooglePlayServices {
                 RunOnMainThread.Cancel(autoResolveJobId);
                 autoResolveJobId = 0;
                 // Remove any enqueued auto-resolve jobs.
-                resolutionJobs.RemoveAll((jobInfo) => {
-                        return jobInfo != null && jobInfo.IsAutoResolveJob;
-                    });
+                resolutionJobs.RemoveAll((jobInfo) => jobInfo == null || jobInfo.IsAutoResolveJob);
                 firstJob = resolutionJobs.Count == 0;
 
                 resolutionJobs.Add(


### PR DESCRIPTION
Before starting auto-resolution a window is displayed that allows the user to
skip the process.  The delay time can be configured via the settings menu.

Change-Id: I8c073a537a07aadcd26c719676ea7d029df93db9