### PR TITLE
Version control checkout code for various files.

### DIFF
--- a/source/PlayServicesResolver/src/GradleTemplateResolver.cs
+++ b/source/PlayServicesResolver/src/GradleTemplateResolver.cs
@@ -326,6 +326,12 @@ namespace GooglePlayServices {
                 }
                 outputLines.AddRange(currentOutputLines);
             }
+            if (!FileUtils.CheckoutFile(GradleTemplatePath))
+            {
+                PlayServicesResolver.Log(
+                    String.Format("Unable to checkou '{0}'.", GradleTemplatePath), level: LogLevel.Error);
+                return false;
+            }
             PlayServicesResolver.Log(
                 String.Format("Writing updated {0}", fileDescription),
                 level: LogLevel.Verbose);

--- a/source/PlayServicesResolver/src/LocalMavenRepository.cs
+++ b/source/PlayServicesResolver/src/LocalMavenRepository.cs
@@ -129,6 +129,11 @@ namespace GooglePlayServices {
                     updatedPackaging = true;
                 }
             }
+            if (!FileUtils.CheckoutFile(pomFilename))
+            {
+                PlayServicesResolver.Log(String.Format("Unable to checkout '{0}'.", pomFilename), LogLevel.Error);
+                return false;
+            }
             if (updatedPackaging) {
                 try {
                     using (var xmlWriter =

--- a/source/PlayServicesResolver/src/PlayServicesResolver.cs
+++ b/source/PlayServicesResolver/src/PlayServicesResolver.cs
@@ -97,6 +97,13 @@ namespace GooglePlayServices {
             public void WriteToFile() {
                 try {
                     Directory.CreateDirectory(Path.GetDirectoryName(DEPENDENCY_STATE_FILE));
+                    if (!FileUtils.CheckoutFile(DEPENDENCY_STATE_FILE))
+                    {
+                        logger.Log(
+                            String.Format("Unable to checkout '{0}'. Dependency state has not been saved!",
+                                DEPENDENCY_STATE_FILE), LogLevel.Error);
+                        return;
+                    }
                     using (var writer = new XmlTextWriter(new StreamWriter(DEPENDENCY_STATE_FILE)) {
                             Formatting = Formatting.Indented,
                         }) {

--- a/source/VersionHandlerImpl/src/FileUtils.cs
+++ b/source/VersionHandlerImpl/src/FileUtils.cs
@@ -288,5 +288,26 @@ namespace Google {
             }
             return NormalizePathSeparators(searchDirectory);
         }
+
+        /// <summary>
+        /// Checks out a file should Version Control be active and valid.
+        /// </summary>
+        /// <param name="path">Path to the file that needs checking out.</param>
+        /// <returns>False should the checkout fail, otherwise true.</returns>
+        public static bool CheckoutFile(string path)
+        {
+            if (UnityEditor.VersionControl.Provider.enabled && UnityEditor.VersionControl.Provider.isActive &&
+                (!UnityEditor.VersionControl.Provider.requiresNetwork ||
+                 UnityEditor.VersionControl.Provider.onlineState == UnityEditor.VersionControl.OnlineState.Online))
+            {
+                var task = UnityEditor.VersionControl.Provider.Checkout(path,
+                    UnityEditor.VersionControl.CheckoutMode.Exact);
+                task.Wait();
+                if (!task.success)
+                    return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/source/VersionHandlerImpl/src/ProjectSettings.cs
+++ b/source/VersionHandlerImpl/src/ProjectSettings.cs
@@ -406,14 +406,12 @@ namespace Google {
                     return;
                 }
                 Directory.CreateDirectory(Path.GetDirectoryName(PROJECT_SETTINGS_FILE));
-                if (UnityEditor.VersionControl.Provider.enabled && UnityEditor.VersionControl.Provider.isActive &&
-                    (!UnityEditor.VersionControl.Provider.requiresNetwork ||
-                     UnityEditor.VersionControl.Provider.onlineState == UnityEditor.VersionControl.OnlineState.Online)) {
-                    var task = UnityEditor.VersionControl.Provider.Checkout(PROJECT_SETTINGS_FILE, 
-                                                                        UnityEditor.VersionControl.CheckoutMode.Exact);
-                    task.Wait();
-                    if (!task.success)
-                        return;
+                if (!FileUtils.CheckoutFile(PROJECT_SETTINGS_FILE))
+                {
+                    logger.Log(
+                        String.Format("Unable to checkout '{0}'. Project settings have not been saved!",
+                            PROJECT_SETTINGS_FILE), LogLevel.Error);
+                    return;
                 }
                 using (var writer = new XmlTextWriter(new StreamWriter(PROJECT_SETTINGS_FILE)) {
                         Formatting = Formatting.Indented,


### PR DESCRIPTION
This is a fixed version of #258 

Includes;
Static checkout function.
Checkout code for dependency file, project settings, mainTemplate.gradle and POM writing.

In the previous request you raised concerns about;

https://github.com/googlesamples/unity-jar-resolver/blob/56d476e23464f797d8c90b5fac0958af2e0887db/source/PlayServicesResolver/src/PlayServicesResolver.cs#L1394

and 

https://github.com/googlesamples/unity-jar-resolver/blob/56d476e23464f797d8c90b5fac0958af2e0887db/source/PlayServicesResolver/src/GradleResolver.cs#L1070

However, I have found that deleting and adding files to be fine (standard resolution works with .aar files) and so i'm loathed to add any checkout code here. The problem seems to be modifying existing files that could be write protected.

Hopefully this request is more suitable than the last. Please let me know of any problems.