### PR TITLE
Improved mainTemplate.gradle file using substitution for unity path

### DIFF
--- a/source/PlayServicesResolver/src/PlayServicesResolver.cs
+++ b/source/PlayServicesResolver/src/PlayServicesResolver.cs
@@ -1891,9 +1891,8 @@ namespace GooglePlayServices {
                 // generate the root Gradle project in "Temp/gradleOut" when *not* exporting a
                 // gradle project.
                 lines.Add(String.Format(
-                          "        def unityProjectPath = \"{0}\" + " +
-                          "file(rootProject.projectDir.path + \"/../../\").absolutePath",
-                          GradleWrapper.FILE_SCHEME));
+						  "        def unityProjectPath = \"{0}**DIR_UNITYPROJECT**\"",
+						  GradleWrapper.FILE_SCHEME));
                 lines.Add("        maven {");
                 lines.Add("            url \"https://maven.google.com\"");
                 lines.Add("        }");

--- a/source/PlayServicesResolver/test/resolve_async/ExpectedArtifacts/NoExport/GradleTemplate/mainTemplate.gradle
+++ b/source/PlayServicesResolver/test/resolve_async/ExpectedArtifacts/NoExport/GradleTemplate/mainTemplate.gradle
@@ -22,7 +22,7 @@ allprojects {
 // Android Resolver Repos Start
 ([rootProject] + (rootProject.subprojects as List)).each { project ->
     project.repositories {
-        def unityProjectPath = "file:///" + file(rootProject.projectDir.path + "/../../").absolutePath
+        def unityProjectPath = "file:///**DIR_UNITYPROJECT**"
         maven {
             url "https://maven.google.com"
         }

--- a/source/PlayServicesResolver/test/resolve_async/ExpectedArtifacts/NoExport/GradleTemplateJetifier/mainTemplate.gradle
+++ b/source/PlayServicesResolver/test/resolve_async/ExpectedArtifacts/NoExport/GradleTemplateJetifier/mainTemplate.gradle
@@ -28,7 +28,7 @@ allprojects {
 }
 ([rootProject] + (rootProject.subprojects as List)).each { project ->
     project.repositories {
-        def unityProjectPath = "file:///" + file(rootProject.projectDir.path + "/../../").absolutePath
+        def unityProjectPath = "file:///**DIR_UNITYPROJECT**"
         maven {
             url "https://maven.google.com"
         }

--- a/source/PlayServicesResolver/test/resolve_async/ExpectedArtifacts/NoExport/GradleTemplateLibrary/mainTemplate.gradle
+++ b/source/PlayServicesResolver/test/resolve_async/ExpectedArtifacts/NoExport/GradleTemplateLibrary/mainTemplate.gradle
@@ -22,7 +22,7 @@ allprojects {
 // Android Resolver Repos Start
 ([rootProject] + (rootProject.subprojects as List)).each { project ->
     project.repositories {
-        def unityProjectPath = "file:///" + file(rootProject.projectDir.path + "/../../").absolutePath
+        def unityProjectPath = "file:///**DIR_UNITYPROJECT**"
         maven {
             url "https://maven.google.com"
         }


### PR DESCRIPTION
When the resolver runs.. it will modify the gradle template and include a line like this:

def unityProjectPath = "file:///" + file(rootProject.projectDir.path + "/../../").absolutePath

This only works if you export the project build to a path that is 2 deep under the main unity project. Internally that will work when building the entire project in unity, but if you export the gradleProject to a location that is not 2 deep relative to the unity project it will fail to build due to not finding the unity project path.

Fortunately Unity exposes a few macros that allows for substitution of some items, one of them being the path to the UnityProject. If you change that line to:

def unityProjectPath = "file:///**DIR_UNITYPROJECT**"

It should always correctly get the absolute path to the unity project during the build or export phase.