### PR TITLE
Allow appending to generated podfile before install runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,25 @@ The `CocoaPods` are either:
 The resolution strategy can be changed via the
 `Assets > Play Services Resolver > iOS Resolver > Settings` menu.
 
+### Appending text to generated Podfile
+In order to modify the generated Podfile you can create a script like this:
+```
+using System.IO;
+public class PostProcessIOS : MonoBehaviour {
+[PostProcessBuildAttribute(45)]//must be between 40 and 50 to ensure that it's not overriden by Podfile generation (40) and that it's added before "pod install" (50)
+private static void PostProcessBuild_iOS(BuildTarget target, string buildPath)
+{
+    if (target == BuildTarget.iOS)
+    {
+
+        using (StreamWriter sw = File.AppendText(buildPath + "/Podfile"))
+        {   
+            //in this example I'm adding an app extension
+            sw.WriteLine("\ntarget 'NSExtension' do\n  pod 'Firebase/Messaging', '6.6.0'\nend");
+        }
+    }
+}
+```
 # Version Handler Usage
 
 The Version Handler component of this plugin manages:

--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -388,12 +388,12 @@ public class IOSResolver : AssetPostprocessor {
         new SortedDictionary<string, Pod>();
 
     // Order of post processing operations.
-    private const int BUILD_ORDER_REFRESH_DEPENDENCIES = 1;
-    private const int BUILD_ORDER_CHECK_COCOAPODS_INSTALL = 2;
-    private const int BUILD_ORDER_PATCH_PROJECT = 3;
-    private const int BUILD_ORDER_GEN_PODFILE = 4;
-    private const int BUILD_ORDER_INSTALL_PODS = 5;
-    private const int BUILD_ORDER_UPDATE_DEPS = 6;
+    private const int BUILD_ORDER_REFRESH_DEPENDENCIES = 10;
+    private const int BUILD_ORDER_CHECK_COCOAPODS_INSTALL = 20;
+    private const int BUILD_ORDER_PATCH_PROJECT = 30;
+    private const int BUILD_ORDER_GEN_PODFILE = 40;
+    private const int BUILD_ORDER_INSTALL_PODS = 50;
+    private const int BUILD_ORDER_UPDATE_DEPS = 60;
 
     // This is appended to the Podfile filename to store a backup of the original Podfile.
     // ie. "Podfile_Unity".


### PR DESCRIPTION
https://github.com/googlesamples/unity-jar-resolver/issues/286
multiplied execution order attributes by 10 so podfile can be alterer after generation but before pod install runs