### PR TITLE
Send forceUpdate parameter as positional arg instead of named arg to …

### DIFF
--- a/source/VersionHandler/src/VersionHandler.cs
+++ b/source/VersionHandler/src/VersionHandler.cs
@@ -381,9 +381,7 @@ public class VersionHandler {
     /// </summary>
     public static void UpdateVersionedAssets(bool forceUpdate = false) {
         InvokeImplMethod("UpdateVersionedAssets",
-                         namedArgs: new Dictionary<string, object> {
-                             { "forceUpdate", forceUpdate }
-                         },
+                         args: new object[] { forceUpdate },
                          schedule: true);
     }
 


### PR DESCRIPTION
…prevent "VersionHandlerImpl.UpdateVersionedAssets not found".

[Play Games Plugin for Unity](https://github.com/playgameservices/play-games-plugin-for-unity) is depending on unity-jar-resolver. With the latest version v10.04 of PGS Plugin, developers started to see `Invalid classname: Method - VersionHandlerImpl.UpdateVersionedAssets` error, when they click Setup in Google Play Games - Android Configuration window. See the associated issues opened on [Play Games Plugin](https://github.com/playgameservices/play-games-plugin-for-unity/issues/2753) side and on [Unity Jar Resolver](https://github.com/googlesamples/unity-jar-resolver/issues/284) side.

I've tried different versions of Unity Jar Resolver with different versions of Play Games Plugin and the issue starts with Unity Jar Resolver v1.2.125. The reason for that is the change of signature of the method `UpdateVersionedAssets` [here](https://github.com/googlesamples/unity-jar-resolver/commit/6e214c8bacd36a247f3fb396a3295aac79451d94#diff-060ef1ed66ed6e2a143dd39e32026239L1841-R1871) in `VersionHandlerImpl.cs`, which causes ending up [here](https://github.com/googlesamples/unity-jar-resolver/blob/43d700803aa9e2680d9254ea706a3b6b6c2bc1da/source/VersionHandler/src/VersionHandler.cs#L540-L543), as `forceUpdate` is still given as `namedArgs` [here](https://github.com/googlesamples/unity-jar-resolver/blob/43d700803aa9e2680d9254ea706a3b6b6c2bc1da/source/VersionHandler/src/VersionHandler.cs#L382-L388). 

Sending forceUpdate parameter as a positional arg solves the issue. Another alternative could be changing the condition [here](https://github.com/googlesamples/unity-jar-resolver/blob/43d700803aa9e2680d9254ea706a3b6b6c2bc1da/source/VersionHandler/src/VersionHandler.cs#L525), but it will probably have implications which I haven't researched now.