### PR TITLE
Unity OpenJDK path changed (2019.3.0, 2019.3.1)

### DIFF
--- a/source/PlayServicesResolver/src/JavaUtilities.cs
+++ b/source/PlayServicesResolver/src/JavaUtilities.cs
@@ -64,7 +64,13 @@ namespace GooglePlayServices {
                             "Editor", "").Replace("OSX", "MacOS");
                         var openJdkDir = Path.Combine(Path.Combine(Path.Combine(
                             androidPlayerDir, "Tools"), "OpenJDK"), platformDir);
-                        if (Directory.Exists(openJdkDir)) javaHome = openJdkDir;
+                        if (Directory.Exists(openJdkDir)) {
+                            javaHome = openJdkDir;
+                        }
+                        else {
+                            openJdkDir = Path.Combine(androidPlayerDir, "OpenJDK");
+                            if (Directory.Exists(openJdkDir)) javaHome = openJdkDir;
+                        }
                     }
                 }
                 // If the JDK stil isn't found, check the environment.


### PR DESCRIPTION
add some lines to handle a new Unity OpenJDK path.
before
/Applications/Unity/Hub/Editor/{UnityVersion}/PlaybackEngines/AndroidPlayer/Tools/OpenJDK/{platform}
after
/Applications/Unity/Hub/Editor/{UnityVersion}/PlaybackEngines/AndroidPlayer/OpenJDK/