### PR TITLE
Use the jdkRootPath provided by Unity

### DIFF
--- a/source/PlayServicesResolver/src/JavaUtilities.cs
+++ b/source/PlayServicesResolver/src/JavaUtilities.cs
@@ -58,20 +58,19 @@ namespace GooglePlayServices {
                 // Unity 2019.x added installation of the JDK in the AndroidPlayer directory
                 // so fallback to searching for it there.
                 if (String.IsNullOrEmpty(javaHome) || EditorPrefs.GetBool("JdkUseEmbedded")) {
+#if UNITY_2019_3_OR_NEWER
+                    var openJdkDir = UnityEditor.Android.AndroidExternalToolsSettings.jdkRootPath;
+                    if (Directory.Exists(openJdkDir)) javaHome = openJdkDir;
+#else
                     var androidPlayerDir = PlayServicesResolver.AndroidPlaybackEngineDirectory;
                     if (!String.IsNullOrEmpty(androidPlayerDir)) {
                         var platformDir = UnityEngine.Application.platform.ToString().Replace(
                             "Editor", "").Replace("OSX", "MacOS");
                         var openJdkDir = Path.Combine(Path.Combine(Path.Combine(
                             androidPlayerDir, "Tools"), "OpenJDK"), platformDir);
-                        if (Directory.Exists(openJdkDir)) {
-                            javaHome = openJdkDir;
-                        }
-                        else {
-                            openJdkDir = Path.Combine(androidPlayerDir, "OpenJDK");
-                            if (Directory.Exists(openJdkDir)) javaHome = openJdkDir;
-                        }
+                        if (Directory.Exists(openJdkDir)) javaHome = openJdkDir;
                     }
+#endif
                 }
                 // If the JDK stil isn't found, check the environment.
                 if (String.IsNullOrEmpty(javaHome)) {


### PR DESCRIPTION
Since 2019.3 version, Unity has changed embedded JDK path and provided UnityEditor.Android.AndroidExternalToolsSettings.jdkRootPath API (https://docs.unity3d.com/2019.3/Documentation/ScriptReference/Android.AndroidExternalToolsSettings-jdkRootPath.html).
Previous MR(https://github.com/googlesamples/unity-jar-resolver/pull/325) wasn't enough to handle embedded JDK path, so I reverted it and changed codes to use Unity API.