### PR TITLE
Improved inline xml documentation

### DIFF
--- a/source/AndroidResolver/src/AndroidAbis.cs
+++ b/source/AndroidResolver/src/AndroidAbis.cs
@@ -143,7 +143,7 @@ internal class AndroidAbis {
     /// <summary>
     /// Create a set of ABIs from a comma separated set of ABI strings.
     /// </summary>
-    /// <param name="abisSet">Set of ABI strings.</param>
+    /// <param name="abiString">Comma separated set of ABI strings.</param>
     public AndroidAbis(string abiString) {
         if (String.IsNullOrEmpty(abiString)) {
             abis = new HashSet<string>(Supported);
@@ -190,7 +190,7 @@ internal class AndroidAbis {
     /// Get the supported set of Android ABIs for the current Unity version.
     /// The dictionary maps the official Android ABI name (i.e the directory name looked up by the
     /// operating system) to the UnityEditor.AndroidTargetDevice (Unity 5.x & 2017.x) or
-    // UnityEditor.AndroidArchitecture enumeration value name.
+    /// UnityEditor.AndroidArchitecture enumeration value name.
     /// </summary>
     private static Dictionary<string, string> SupportedAbiToAbiEnumValue {
         get { return PropertyConfiguration.Instance.SupportedAbiToAbiEnumValue; }
@@ -221,10 +221,10 @@ internal class AndroidAbis {
     /// </summary>
     /// <param name="enumValueObject">Enum object to convert.</param>
     private static ulong EnumValueObjectToULong(object enumValueObject) {
-        /// Flags enum values can't be cast directly to an integral type, however it is possible to
-        /// print the value as an integer string so convert to a string and then parse as an int.
-        /// Enums are considered unsigned by the formatter, so if an enum is defined as -1 it will
-        /// be formatted as UInt32.MaxValue, i.e. 4294967295.
+        // Flags enum values can't be cast directly to an integral type, however it is possible to
+        // print the value as an integer string so convert to a string and then parse as an int.
+        // Enums are considered unsigned by the formatter, so if an enum is defined as -1 it will
+        // be formatted as UInt32.MaxValue, i.e. 4294967295.
         return UInt64.Parse(String.Format("{0:D}", enumValueObject));
     }
 
@@ -240,7 +240,7 @@ internal class AndroidAbis {
     /// <summary>
     /// Get / set the target device ABI (Unity >= 5.0.x)
     /// Unity >= 2017.4 supports armeabi-v7a, arm64-v8a, x86 & fat (i.e armeabi-v7a, arm64, x86)
-    /// Unity >= 5.0.x & <= 2017.3 only support armeabi-v7a, x86 & fat (i.e armeabi-v7a & x86)
+    /// Unity >= 5.0.x & &lt;= 2017.3 only support armeabi-v7a, x86 & fat (i.e armeabi-v7a & x86)
     /// </summary>
     public static AndroidAbis Current {
         set {

--- a/source/AndroidResolver/src/AndroidSdkManager.cs
+++ b/source/AndroidResolver/src/AndroidSdkManager.cs
@@ -975,7 +975,7 @@ namespace GooglePlayServices {
         /// </summary>
         /// <param name="toolName">Name of the tool to search for.</param>
         /// <param name="sdkPath">SDK path to search for the tool.  If this is null or empty, the
-        // system path is searched instead.</param>
+        /// system path is searched instead.</param>
         /// <returns>String with the path to the tool if found, null otherwise.</returns>
         private static string FindAndroidSdkTool(string toolName, string sdkPath = null) {
             if (String.IsNullOrEmpty(sdkPath)) {

--- a/source/AndroidResolver/src/CommandLine.cs
+++ b/source/AndroidResolver/src/CommandLine.cs
@@ -375,7 +375,7 @@ namespace GooglePlayServices
             /// a newline isn't present.
             /// </summary>
             /// <param name="handle">Handle of the stream to query.</param>
-            /// <returns>List of data for the requested stream.</return>
+            /// <returns>List of data for the requested stream.</returns>
             public List<StreamData> GetBufferedData(int handle)
             {
                 List<StreamData> handleData;
@@ -397,7 +397,6 @@ namespace GooglePlayServices
             /// <summary>
             /// Aggregate the specified list of StringBytes into a single structure.
             /// </summary>
-            /// <param name="handle">Stream handle.</param>
             /// <param name="dataStream">Data to aggregate.</param>
             public static StreamData Aggregate(List<StreamData> dataStream)
             {

--- a/source/AndroidResolver/src/EmbeddedResource.cs
+++ b/source/AndroidResolver/src/EmbeddedResource.cs
@@ -132,7 +132,7 @@ namespace Google {
         /// directories if they're required.
         /// </summary>
         /// <param name="assembly">Assembly to extract resources from.</param>
-        /// <param name="resourceNameToTargetPath">Each Key is the resource to extract and each
+        /// <param name="resourceNameToTargetPaths">Each Key is the resource to extract and each
         /// Value is the path to extract to. If the resource name (Key) is null or empty, this
         /// method will attempt to extract a resource matching the filename component of the path.
         /// </param>

--- a/source/AndroidResolver/src/GradleResolver.cs
+++ b/source/AndroidResolver/src/GradleResolver.cs
@@ -139,7 +139,7 @@ namespace GooglePlayServices
         /// * Path relative to project folder, ex."Assets/Firebase/m2repository"
         /// </summary>
         /// <param name="repoPath">Repo path to convert.</param>
-        /// <param name="sourceLocation>XML or source file this path is referenced from. If this is
+        /// <param name="sourceLocation">XML or source file this path is referenced from. If this is
         /// null the calling method's source location is used when logging the source of this
         /// repo declaration.</param>
         /// <returns>URI to the repo.</returns>
@@ -1025,9 +1025,12 @@ namespace GooglePlayServices
         /// <summary>
         /// Processes the aars.
         /// </summary>
-        /// <remarks>Each aar copied is inspected and determined if it should be
+        /// <remarks>
+        /// <para>
+        /// Each aar copied is inspected and determined if it should be
         /// exploded into a directory or not. Unneeded exploded directories are
         /// removed.
+        /// </para>
         /// <para>
         /// Exploding is needed if the version of Unity is old, or if the artifact
         /// has been explicitly flagged for exploding.  This allows the subsequent
@@ -1035,6 +1038,7 @@ namespace GooglePlayServices
         /// supported by the current versions of the manifest merging process that
         /// Unity uses.
         /// </para>
+        /// </remarks>
         /// <param name="dir">The directory to process.</param>
         /// <param name="updatedFiles">Set of files that were recently updated and should be
         /// processed.</param>

--- a/source/AndroidResolver/src/GradleWrapper.cs
+++ b/source/AndroidResolver/src/GradleWrapper.cs
@@ -133,7 +133,7 @@ namespace Google {
         /// <param name="buildScript">Path to the Gradle build script to use.</param>
         /// <param name="projectProperties">Project properties to use when running the script.
         /// </param>
-        /// <param name="arguments>Other arguments to pass to Gradle.</param>
+        /// <param name="arguments">Other arguments to pass to Gradle.</param>
         /// <param name="logger">Logger to report errors to.</param>
         /// <param name="executeCommand">Closure which takes the tool path to execute
         /// (gradle wrapper) and a string of arguments returning true if successful,

--- a/source/AndroidResolver/src/JavaUtilities.cs
+++ b/source/AndroidResolver/src/JavaUtilities.cs
@@ -132,7 +132,7 @@ namespace GooglePlayServices {
         /// <summary>
         /// Find a Java tool.
         /// </summary>
-        /// <param name="toolName">Name of the tool to search for.</param>
+        /// <param name="javaTool">Name of the tool to search for.</param>
         /// <returns>Path to the tool if it's found, throws a ToolNotFoundException
         /// otherwise.</returns>
         private static string FindJavaTool(string javaTool)

--- a/source/AndroidResolver/src/LocalMavenRepository.cs
+++ b/source/AndroidResolver/src/LocalMavenRepository.cs
@@ -82,7 +82,7 @@ namespace GooglePlayServices {
         /// <summary>
         /// Get a path without a filename extension.
         /// </summary>
-        /// <param name="filename">Path to a file.</param>
+        /// <param name="path">Path to a file.</param>
         /// <returns>Path (including directory) without a filename extension.</returns>
         internal static string PathWithoutExtension(string path) {
             return Path.Combine(Path.GetDirectoryName(path),

--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -261,7 +261,7 @@ namespace GooglePlayServices {
             /// <summary>
             /// Convert a dictionary to a sorted comma separated string.
             /// </summary>
-            /// <returns>Comma separated string in the form key=value.<returns>
+            /// <returns>Comma separated string in the form key=value.</returns>
             private static string DictionaryToString(Dictionary<string, string> dict) {
                 var components = new List<string>();
                 foreach (var key in SortSet(dict.Keys)) {
@@ -319,7 +319,7 @@ namespace GooglePlayServices {
             /// <param name="delayTimeInSeconds">Time to wait before signalling that the value
             /// has changed.</param>
             /// <param name="checkIntervalInSeconds">Time to check the value of the property for
-            /// changes.<param>
+            /// changes.</param>
             public PropertyPoller(string propertyName,
                                   int delayTimeInSeconds = 3,
                                   int checkIntervalInSeconds = 1) {
@@ -628,7 +628,7 @@ namespace GooglePlayServices {
         /// </summary>
         private struct AndroidBuildSystemSettings {
             /// <summary>
-            // Whether the Gradle build is enabled.
+            /// Whether the Gradle build is enabled.
             /// </summary>
             public bool GradleBuildEnabled { get; private set; }
 
@@ -638,7 +638,7 @@ namespace GooglePlayServices {
             public bool GradleTemplateEnabled { get; private set; }
 
             /// <summary>
-            // Whether project export is enabled.
+            /// Whether project export is enabled.
             /// </summary>
             public bool ProjectExportEnabled { get; private set; }
 
@@ -656,7 +656,7 @@ namespace GooglePlayServices {
             }
 
             /// <summary>
-            // Compare with another AndroidBuildSystemSettings.
+            /// Compare with another AndroidBuildSystemSettings.
             /// </summary>
             /// <param name="obj">Object to compare with.</param>
             /// <returns>true if the object is the same as this, false otherwise.</returns>
@@ -1199,7 +1199,7 @@ namespace GooglePlayServices {
         /// * foo.com.my.app.service --> foo.com.my.app.service (unchanged)
         /// </param>
         /// <param name="path">Path of this node in the hierarchy of nodes. For example:
-        /// given node is "<c>" in "<a><b><c>" this should be "a/b/c".  If this
+        /// given node is "&lt;c>" in "&lt;a>&lt;b>&lt;c>" this should be "a/b/c".  If this
         /// value is null the name of the current node is used.</param>
         /// <returns>true if any replacements are applied, false otherwise.</returns>
         private static bool ReplaceVariablesInXmlElementTree(

--- a/source/AndroidResolver/src/UnityCompat.cs
+++ b/source/AndroidResolver/src/UnityCompat.cs
@@ -399,7 +399,7 @@ public class UnityCompat {
     /// </summary>
     /// Unfortunately the Unity API does not provide a way to get the current BuildTargetGroup from
     /// the currently active BuildTarget.
-    /// <param name="target">BuildTarget to convert.</param>
+    /// <param name="buildTarget">BuildTarget to convert.</param>
     /// <returns>BuildTargetGroup enum value.</returns>
     private static BuildTargetGroup ConvertBuildTargetToBuildTargetGroup(BuildTarget buildTarget) {
         var buildTargetToGroup = new Dictionary<string, string>() {

--- a/source/AndroidResolver/test/src/AndroidResolverIntegrationTests.cs
+++ b/source/AndroidResolver/test/src/AndroidResolverIntegrationTests.cs
@@ -672,6 +672,7 @@ public class AndroidResolverIntegrationTests {
     /// This filters all Unity .meta files from the resultant list.
     /// </summary>
     /// <param name="searchDir">Directory to search.</param>
+    /// <param name="filesToIgnore">Set of files to relative to the generatedAssetsDir.</param>
     /// <param name="relativeDir">Root path for relative filenames.  This should be any directory
     /// under the specified searchDir argument.  If this is null, searchDir is used.</param>
     /// <returns>Dictionary of file paths mapped to relative file paths.</returns>

--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -72,7 +72,7 @@ public class IOSResolver : AssetPostprocessor {
         /// Since order is important sources specified in this list
         /// are interleaved across each Pod added to the resolver.
         /// e.g Pod1.source[0], Pod2.source[0] ...
-        ////    Pod1.source[1], Pod2.source[1] etc.
+        ///     Pod1.source[1], Pod2.source[1] etc.
         ///
         /// See: https://guides.cocoapods.org/syntax/podfile.html#source
         /// </summary>
@@ -186,9 +186,9 @@ public class IOSResolver : AssetPostprocessor {
 
         /// <summary>
         /// Convert min target SDK to an integer in the form
-        // (major * 10) + minor.
+        /// (major * 10) + minor.
         /// </summary>
-        /// <return>Numeric minimum SDK revision required by this pod.</return>
+        /// <returns>Numeric minimum SDK revision required by this pod.</returns>
         public int MinTargetSdkToVersion() {
             string sdkString =
                 String.IsNullOrEmpty(minTargetSdk) ? "0.0" : minTargetSdk;
@@ -1330,7 +1330,7 @@ public class IOSResolver : AssetPostprocessor {
 
     /// <summary>
     /// Convert a target SDK string into a value of the form
-    // (major * 10) + minor.
+    /// (major * 10) + minor.
     /// </summary>
     /// <returns>Integer representation of the SDK.</returns>
     internal static int TargetSdkStringToVersion(string targetSdk) {
@@ -1366,7 +1366,7 @@ public class IOSResolver : AssetPostprocessor {
     /// <summary>
     /// Determine whether any pods need bitcode disabled.
     /// </summary>
-    /// <returns>List of pod names with bitcode disabled.</return>
+    /// <returns>List of pod names with bitcode disabled.</returns>
     private static List<string> FindPodsWithBitcodeDisabled() {
         var disabled = new List<string>();
         foreach (var pod in pods.Values) {
@@ -1839,7 +1839,7 @@ public class IOSResolver : AssetPostprocessor {
     /// this returns the string...
     ///
     /// source 'http://myrepo.com/Specs.git'
-    /// source 'http://anotherrepo.com/Specs.git'
+    /// source 'http://anotherrepo.com/Specs.git'</returns>
     private static string GeneratePodfileSourcesSection() {
         var interleavedSourcesLines = new List<string>();
         var processedSources = new HashSet<string>();
@@ -2064,7 +2064,7 @@ public class IOSResolver : AssetPostprocessor {
         /// Delegate method associated with the container.  This enables the
         /// following pattern:
         ///
-        /// var container = new DelegateContainer<CommandLine.CompletionHandler>();
+        /// var container = new DelegateContainer&lt;CommandLine.CompletionHandler>();
         /// container.Handler = (CommandLine.Result result) => { RunNext(container.Handler); };
         /// </summary>
         public T Handler { get; set; }

--- a/source/IntegrationTester/src/Runner.cs
+++ b/source/IntegrationTester/src/Runner.cs
@@ -116,7 +116,6 @@ namespace Google.IntegrationTester {
         /// <summary>
         /// Add a single test case to the list to be executed.
         /// </summary>
-        /// <remarks>
         /// <param name="test">Test case to add to the list to execute.</param>
         public static void ScheduleTestCase(TestCase test) {
             testCases.Add(test);
@@ -139,7 +138,6 @@ namespace Google.IntegrationTester {
         /// <remarks>
         /// Finds and calls all initialization methods with the InitializerAttribute.
         /// </remarks>
-        /// <param name="unityVersion">Major & minor version of Unity.</param>
         private static void ConfigureTestCases() {
             unityVersion = Google.VersionHandler.GetUnityVersionMajorMinor();
 
@@ -332,8 +330,8 @@ namespace Google.IntegrationTester {
         }
 
         /// <summary>
-        // Log a test case result to the journal so that it isn't executed again if the app
-        // domain is reloaded.
+        /// Log a test case result to the journal so that it isn't executed again if the app
+        /// domain is reloaded.
         /// </summary>
         private static bool WriteTestCaseResult(TestCaseResult testCaseResult) {
             var existingTestCaseResults = ReadTestCaseResults();

--- a/source/PackageManagerResolver/src/PackageManagerClient.cs
+++ b/source/PackageManagerResolver/src/PackageManagerClient.cs
@@ -56,7 +56,9 @@ internal static class PackageManagerClient {
         /// Convert a collection of objects to a field separated string.
         /// </summary>
         /// <param name="objects">Collection of objects to convert to a list of strings.</param>
-        /// <returns>Comma separated string.</returns>.
+        /// <param name="separator">The string to use as a separator.</param>
+        /// <returns>A string that consists of members of <paramref name="objects"/> delimited
+        /// by <paramref name="separator"/> string.</returns>.
         protected static string ObjectCollectionToString<T>(IEnumerable<T> objects,
                                                             string separator) {
             var components = new List<string>();
@@ -968,7 +970,7 @@ internal static class PackageManagerClient {
         /// Construct the instance.
         /// </summary>
         /// <param name="items">Items to iterate through.</param>
-        /// <param name="progress">Reports progress as iteration proceeds.</param>
+        /// <param name="progressReporter">Reports progress as iteration proceeds.</param>
         public EnumeratorProgressReporter(ICollection<string> items,
                                    Action<float, string> progressReporter) {
             itemCount = items.Count;
@@ -1081,6 +1083,7 @@ internal static class PackageManagerClient {
         /// Install a set of packages using the package manager.
         /// </summary>
         /// <param name="packageIdsOrNames">Package IDs or names to search for.</param>
+        /// <param name="complete">Called when the operation is complete.</param>
         /// <param name="progress">Reports progress through the search.</param>
         public PackageInstaller(ICollection<string> packageIdsOrNames,
                                 Action<Dictionary<string, InstallResult>> complete,
@@ -1163,6 +1166,7 @@ internal static class PackageManagerClient {
         /// Search for a set of packages in the package manager.
         /// </summary>
         /// <param name="packageIdsOrNames">Package IDs or names to search for.</param>
+        /// <param name="complete">Called when the operation is complete.</param>
         /// <param name="progress">Reports progress through the search.</param>
         public PackageSearcher(ICollection<string> packageIdsOrNames,
                                Action<Dictionary<string, SearchResult>> complete,
@@ -1245,6 +1249,7 @@ internal static class PackageManagerClient {
     /// Add packages to the project.
     /// </summary>
     /// <param name="packageIdsOrNames">IDs or names of the packages to add.</param>
+    /// <param name="complete">Called when the operation is complete.</param>
     /// <param name="progress">Reports progress through the installation.</param>
     public static void AddPackages(ICollection<string> packageIdsOrNames,
                                    Action<Dictionary<string, InstallResult>> complete,

--- a/source/PackageManagerResolver/src/PackageManagerRegistry.cs
+++ b/source/PackageManagerResolver/src/PackageManagerRegistry.cs
@@ -80,7 +80,7 @@ namespace Google {
         /// <summary>
         /// Convert to a human readable string excluding the TermsOfService and CreatedBy fields.
         /// </summary>
-        /// <returns>String representation of this instance.</return>
+        /// <returns>String representation of this instance.</returns>
         public override string ToString() {
             return String.Format("name: {0}, url: {1}, scopes: {2}",
                                  Name, Url,

--- a/source/PackageManagerResolver/src/PackageManagerResolver.cs
+++ b/source/PackageManagerResolver/src/PackageManagerResolver.cs
@@ -38,9 +38,20 @@ public class PackageManagerResolver : AssetPostprocessor {
     /// The operation to perform when modifying the manifest.
     /// </summary>
     internal enum ManifestModificationMode {
-        Add, /// Add package registries that are not in the manifest.
-        Remove, /// Remove package registries from the manifest that are in the loaded config.
-        Modify, /// Display and add / remove all package registries from the manifest.
+        /// <summary>
+        /// Add package registries that are not in the manifest.
+        /// </summary>
+        Add,
+
+        /// <summary>
+        /// Remove package registries from the manifest that are in the loaded config.
+        /// </summary>
+        Remove,
+
+        /// <summary>
+        /// Display and add / remove all package registries from the manifest.
+        /// </summary>
+        Modify,
     }
 
     private const string ADD_REGISTRIES_QUESTION =
@@ -306,7 +317,7 @@ public class PackageManagerResolver : AssetPostprocessor {
     /// unselected registries.  If true, removes the selected registries and adds the unselected
     /// registries.</param>
     /// <param name="addedRegistries">If specified, is extended with the list of registries added
-    /// to the manifest.<param>
+    /// to the manifest.</param>
     /// <returns>true if successful, false otherwise.</returns>
     private static bool SyncRegistriesToManifest(
             PackageManifestModifier manifestModifier,

--- a/source/PackageManagerResolver/src/PackageManifestModifier.cs
+++ b/source/PackageManagerResolver/src/PackageManifestModifier.cs
@@ -88,7 +88,7 @@ internal class PackageManifestModifier {
     /// <summary>
     /// Read manifest from the file and parse JSON string into a dictionary.
     /// </summary>
-    /// <return>True if read and parsed successfully.</return>
+    /// <returns>True if read and parsed successfully.</returns>
     internal bool ReadManifest() {
         string manifestText;
         try {
@@ -218,7 +218,7 @@ internal class PackageManifestModifier {
     /// <summary>
     /// Add a scoped registries.
     /// </summary>
-    /// <param name="registries">Registries to add to the manifest.</para>
+    /// <param name="registries">Registries to add to the manifest.</param>
     /// <returns>true if the registries are added to the manifest, false otherwise.</returns>
     internal bool AddRegistries(IEnumerable<PackageManagerRegistry> registries) {
         List<object> scopedRegistries;
@@ -249,7 +249,7 @@ internal class PackageManifestModifier {
     /// <summary>
     /// Remove all scoped registries in the given list.
     /// </summary>
-    /// <para, name="registries">A list of scoped registry to be removed</para>
+    /// <param name="registries">A list of scoped registry to be removed</param>
     /// <param name="displayWarning">Whether to display a warning if specified registries were not
     /// found.</param>
     /// <returns>true if the registries could be removed, false otherwise.</returns>
@@ -295,7 +295,7 @@ internal class PackageManifestModifier {
     /// <summary>
     /// Write the dictionary to manifest file.
     /// </summary>
-    /// <return>True if serialized and wrote successfully.</return>
+    /// <returns>True if serialized and wrote successfully.</returns>
     internal bool WriteManifest() {
         if (manifestDict == null) {
             Logger.Log(String.Format("No manifest to write to '{0}'", MANIFEST_FILE_PATH),
@@ -321,7 +321,7 @@ internal class PackageManifestModifier {
     /// <summary>
     /// Get the manifest json string.
     /// </summary>
-    /// <return>Manifest json string.</return>
+    /// <returns>Manifest json string.</returns>
     internal string GetManifestJson() {
         return manifestDict != null ?
                 Json.Serialize(manifestDict, humanReadable: true, indentSpaces: 2) :

--- a/source/PackageManagerResolver/src/PackageMigrator.cs
+++ b/source/PackageManagerResolver/src/PackageMigrator.cs
@@ -190,7 +190,7 @@ internal class PackageMigrator {
         /// Read a set of PackageMap instances from a file.
         /// </summary>
         /// <returns>List of package maps.</returns>
-        /// <exception cref="IOException>Thrown if an error occurs while reading the
+        /// <exception cref="IOException">Thrown if an error occurs while reading the
         /// file.</exception>
         public static ICollection<PackageMap> ReadFromFile() {
             var packageMaps = new List<PackageMap>();
@@ -247,7 +247,7 @@ internal class PackageMigrator {
         /// <summary>
         /// Generate a collection sorted by Version Handler package name.
         /// </summary>
-        /// <returns>Sorted list of package maps.</returns.
+        /// <returns>Sorted list of package maps.</returns>
         private static ICollection<PackageMap> SortedPackageMap(
                 IEnumerable<PackageMap> packages) {
             var sorted = new SortedDictionary<string, PackageMap>();
@@ -262,8 +262,8 @@ internal class PackageMigrator {
         /// <summary>
         /// Write a set of PackageMap instances to a file.
         /// </summary>
-        /// <param name="packageMaps">Package maps to write to a file.<param>
-        /// <exception cref="IOException>Thrown if an error occurs while writing the
+        /// <param name="packageMaps">Package maps to write to a file.</param>
+        /// <exception cref="IOException">Thrown if an error occurs while writing the
         /// file.</exception>
         public static void WriteToFile(ICollection<PackageMap> packageMaps) {
             try {
@@ -406,6 +406,7 @@ internal class PackageMigrator {
         /// </summary>
         /// <param name="refresh">Whether to refresh the cache or data in memory.</param>
         /// <param name="complete">Called when packages have been cached by this class.</param>
+        /// <param name="progressDelegate">Called as the operation progresses.</param>
         public static void CacheAvailablePackageInfo(
                 bool refresh, Action<PackageManagerClient.Error> complete,
                 FindPackagesProgressDelegate progressDelegate) {
@@ -579,7 +580,7 @@ internal class PackageMigrator {
         /// <summary>
         /// Calculate migration progress through the specified list.
         /// </summary>
-        /// <param name="packageMaps">List of packages to migrated.</param>
+        /// <param name="packages">List of packages to migrated.</param>
         /// <returns>A value between 0 (no progress) and 1 (complete).</returns>
         public static float CalculateProgress(ICollection<PackageMap> packages) {
             int total = packages.Count;
@@ -879,7 +880,6 @@ internal class PackageMigrator {
     /// </summary>
     /// <param name="complete">Called when migration is complete with an error message if
     /// it fails.</param>
-    /// <param name="packageMaps">Set of packages to migrate.</param>
     public static void TryMigration(Action<string> complete) {
         if (!Available) {
             complete(NotAvailableMessage);

--- a/source/PackageManagerResolver/test/PackageManagerClientIntegrationTests/PackageManagerClientIntegrationTests.cs
+++ b/source/PackageManagerResolver/test/PackageManagerClientIntegrationTests/PackageManagerClientIntegrationTests.cs
@@ -270,7 +270,7 @@ public static class PackageManagerClientTests {
     /// </summary>
     /// <param name="error">Error to check.</param>
     /// <param name="packageName">Name of the changed package.</param>
-    /// <param name="expectedPackageName">Expected installed / removed package name.<param>
+    /// <param name="expectedPackageName">Expected installed / removed package name.</param>
     /// <param name="testCaseResult">TestCaseResult to add an error message to if the result
     /// indicates a failure or doesn't match the expected package name.</param>
     /// <returns>String description of the result.</returns>

--- a/source/VersionHandler/src/VersionHandler.cs
+++ b/source/VersionHandler/src/VersionHandler.cs
@@ -459,7 +459,7 @@ public class VersionHandler {
     /// </summary>
     /// <param name="objectInstance">Object to call a method on.</param>
     /// <param name="methodName">Name of the method to call.</param>
-    /// <param name="arg">Positional arguments of the method.</param>
+    /// <param name="args">Positional arguments of the method.</param>
     /// <param name="namedArgs">Named arguments of the method.</param>
     /// <returns>object returned by the method.</returns>
     public static object InvokeInstanceMethod(
@@ -475,7 +475,7 @@ public class VersionHandler {
     /// </summary>
     /// <param name="type">Class to call the method on.</param>
     /// <param name="methodName">Name of the method to call.</param>
-    /// <param name="arg">Positional arguments of the method.</param>
+    /// <param name="args">Positional arguments of the method.</param>
     /// <param name="namedArgs">Named arguments of the method.</param>
     /// <returns>object returned by the method.</returns>
     public static object InvokeStaticMethod(
@@ -491,7 +491,7 @@ public class VersionHandler {
     /// <param name="type">Class to call the method on.</param>
     /// <param name="objectInstance">Object to call a method on.</param>
     /// <param name="methodName">Name of the method to call.</param>
-    /// <param name="arg">Positional arguments of the method.</param>
+    /// <param name="args">Positional arguments of the method.</param>
     /// <param name="namedArgs">Named arguments of the method.</param>
     /// <returns>object returned by the method.</returns>
     public static object InvokeMethod(

--- a/source/VersionHandlerImpl/src/DialogWindow.cs
+++ b/source/VersionHandlerImpl/src/DialogWindow.cs
@@ -331,7 +331,7 @@ public class DialogWindow : EditorWindow {
     /// <summary>
     /// Get a list of pairs of the text and enum of each non-empty option.
     /// </summary>
-    /// <return>A list of key-value pair where key is text and value is enum.</return>
+    /// <returns>A list of key-value pair where key is text and value is enum.</returns>
     private List<KeyValuePair<string, Option>> GetOptionList() {
         List<KeyValuePair<string, Option>> options = new List<KeyValuePair<string, Option>>();
 

--- a/source/VersionHandlerImpl/src/EditorMeasurement.cs
+++ b/source/VersionHandlerImpl/src/EditorMeasurement.cs
@@ -240,7 +240,7 @@ public class EditorMeasurement {
     /// Set the installation source from the location of an assembly in the plugin relative to the
     /// project directory. If InstallSource is not null it takes precedence over this property.
     /// </summary>
-    /// <note>This path must use the system directory separator.<note>
+    /// <note>This path must use the system directory separator.</note>
     public string InstallSourceFilename { get; set; }
 
     /// <summary>
@@ -251,7 +251,7 @@ public class EditorMeasurement {
     /// <summary>
     /// Generate common query parameters.
     /// </summary>
-    /// <return>Query string with common parameters.</returns>
+    /// <returns>Query string with common parameters.</returns>
     internal string CommonQuery {
         get {
             var query = "";
@@ -285,7 +285,7 @@ public class EditorMeasurement {
     /// Construct an object to report usage of a plugin.
     /// </summary>
     /// <param name="projectSettings">Settings to store preferences.</param>
-    /// <param name="logger">Logger used to display reported events.</params>
+    /// <param name="logger">Logger used to display reported events.</param>
     /// <param name="analyticsTrackingId">ID used to report analytics data.</param>
     /// <param name="settingsNamespace">Prefix applied to settings stored by this instance.
     /// This should be a globally unique ID. To minimize the chances of collision developers should
@@ -426,7 +426,7 @@ public class EditorMeasurement {
     /// <summary>
     /// Generate an analytics "cookie" / UUID / GUID.
     /// </summary>
-    /// <returns>A cookie string.</return>
+    /// <returns>A cookie string.</returns>
     private static string GenerateCookie() {
         return Guid.NewGuid().ToString().Replace("-", "").ToLower();
     }
@@ -451,7 +451,7 @@ public class EditorMeasurement {
     /// <param name="baseQuery">URL path or query to append to. If this is null or empty
     /// the returned value will be the supplied query argument.</param>
     /// <param name="query">Query to append.</param>
-    /// <return>Path concatenated with the supplied query string.</param>
+    /// <returns>Path concatenated with the supplied query string.</returns>
     internal static string ConcatenateQueryStrings(string baseQuery, string query) {
         if (String.IsNullOrEmpty(query)) return baseQuery;
         if (String.IsNullOrEmpty(baseQuery)) return query;

--- a/source/VersionHandlerImpl/src/FileUtils.cs
+++ b/source/VersionHandlerImpl/src/FileUtils.cs
@@ -234,9 +234,9 @@ namespace Google {
         /// Find a path under the specified directory.
         /// </summary>
         /// <param name="directory">Directory to search.</param>
-        /// <param name="pathToFind">Path to find.<param>
+        /// <param name="pathToFind">Path to find.</param>
         /// <returns>The shortest path to the specified directory if found, null
-        /// ptherwise.</returns>
+        /// otherwise.</returns>
         public static string FindPathUnderDirectory(string directory, string pathToFind) {
             directory = NormalizePathSeparators(directory);
             if (directory.EndsWith(Path.DirectorySeparatorChar.ToString())) {
@@ -539,8 +539,8 @@ namespace Google {
         /// </summary>
         /// <param name = "filenames">Files to be removed/</param>
         /// <param name = "logger">Logger to log results.</param>
-        /// <return>True if all files are removed.  False if failed to remove any file or
-        /// if any file is missing.</return>
+        /// <returns>True if all files are removed.  False if failed to remove any file or
+        /// if any file is missing.</returns>
         public static RemoveAssetsResult RemoveAssets(IEnumerable<string> filenames,
                                                       Logger logger = null) {
             var result = new RemoveAssetsResult();

--- a/source/VersionHandlerImpl/src/MiniJSON.cs
+++ b/source/VersionHandlerImpl/src/MiniJSON.cs
@@ -400,7 +400,7 @@ namespace MiniJSON {
         /// <summary>
         /// Converts a IDictionary / IList object or a simple type (string, int, etc.) into a JSON string
         /// </summary>
-        /// <param name="json">A Dictionary&lt;string, object&gt; / List&lt;object&gt;</param>
+        /// <param name="obj">A Dictionary&lt;string, object&gt; / List&lt;object&gt;</param>
         /// <param name="humanReadable">Whether output as human readable format with spaces and
         /// indentations.</param>
         /// <param name="indentSpaces">Number of spaces for each level of indentation.</param>

--- a/source/VersionHandlerImpl/src/RunOnMainThread.cs
+++ b/source/VersionHandlerImpl/src/RunOnMainThread.cs
@@ -389,7 +389,7 @@ public class RunOnMainThread {
     /// Execute polling jobs, removing completed jobs from the list.
     /// This method must be called from the main thread.
     /// </summary>
-    /// <returns>Number of jobs remaining in the polling job list.<returns>
+    /// <returns>Number of jobs remaining in the polling job list.</returns>
     private static int ExecutePollingJobs() {
         int numberOfPollingJobs;
         bool completedJobs = false;

--- a/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
+++ b/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
@@ -386,7 +386,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// Whether it's possible to change the asset metadata.
         /// </summary>
         /// <returns>true if the asset metadata for this file is read-only,
-        /// false otherwise.</return>
+        /// false otherwise.</returns>
         public bool IsReadOnly {
             get {
                 return FileUtils.IsUnderPackageDirectory(filename);
@@ -414,7 +414,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// Parse metadata from the specified filename and store in this class.
         /// </summary>
         /// <param name="filenameToParse">Parse metadata from the specified filename.</param>
-        /// <retuns>Filename with metadata removed.</returns>
+        /// <returns>Filename with metadata removed.</returns>
         private string ParseMetadataFromFilename(string filenameToParse) {
             var filenameComponents = new FilenameComponents(filenameToParse);
             // Parse metadata from the filename.
@@ -863,7 +863,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// If the version string contains more than MAX_VERSION_COMPONENTS the
         /// remaining components are ignored.
         /// </summary>
-        /// <param name="version">Version string to parse.</param>
+        /// <param name="versionString">Version string to parse.</param>
         /// <returns>64-bit version number.</returns>
         public static long CalculateVersion(string versionString) {
             long versionNumber = 0;
@@ -886,7 +886,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// <summary>
         /// Convert a numeric version back to a version string.
         /// </summary>
-        /// <param name="version">Numeric version number.</param>
+        /// <param name="versionNumber">Numeric version number.</param>
         /// <returns>Version string.</returns>
         public static string VersionNumberToString(long versionNumber) {
             List<string> components = new List<string>();
@@ -1002,7 +1002,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// recent versions.
         /// </summary>
         /// <returns>true if any plugin metadata was modified and requires an
-        /// AssetDatabase.Refresh(), false otherwise.</return>
+        /// AssetDatabase.Refresh(), false otherwise.</returns>
         public bool EnableMostRecentPlugins() {
             return EnableMostRecentPlugins(new HashSet<string>());
         }
@@ -1013,7 +1013,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// </summary>
         /// <param name="disableFiles">Set of files in the project that should be disabled.</param>
         /// <returns>true if any plugin metadata was modified and requires an
-        /// AssetDatabase.Refresh(), false otherwise.</return>
+        /// AssetDatabase.Refresh(), false otherwise.</returns>
         public bool EnableMostRecentPlugins(HashSet<string> disableFiles) {
             bool modified = false;
             int versionIndex = 0;
@@ -1531,7 +1531,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// <param name="forceUpdate">Whether the update was forced by the
         /// user.</param>
         /// <returns>true if any plugin metadata was modified and requires an
-        /// AssetDatabase.Refresh(), false otherwise.</return>
+        /// AssetDatabase.Refresh(), false otherwise.</returns>
         public bool EnableMostRecentPlugins(bool forceUpdate) {
             return EnableMostRecentPlugins(forceUpdate, new HashSet<string>());
         }
@@ -1545,7 +1545,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// user.</param>
         /// <param name="disableFiles">Set of files that should be disabled.</param>
         /// <returns>true if any plugin metadata was modified and requires an
-        /// AssetDatabase.Refresh(), false otherwise.</return>
+        /// AssetDatabase.Refresh(), false otherwise.</returns>
         public bool EnableMostRecentPlugins(bool forceUpdate,
                                             HashSet<string> disableFiles) {
             bool modified = false;
@@ -1635,7 +1635,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// <summary>
         /// Parse metadata from a set of filenames.
         /// </summary>
-        /// <param name="assetFiles">Filenames to parse.</param>
+        /// <param name="filenames">Filenames to parse.</param>
         /// <returns>FileMetadataSet referencing metadata parsed from filenames
         /// ordered by version and bucketed by canonical filename.
         /// </returns>
@@ -1653,7 +1653,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// with metadata that selects the set of target platforms.
         /// </summary>
         /// <param name="metadataSet">Set to filter.</param>
-        /// <returns>Filtered MetadataSet.
+        /// <returns>Filtered MetadataSet.</returns>
         public static FileMetadataSet FindWithPendingUpdates(
                 FileMetadataSet metadataSet) {
             FileMetadataSet outMetadataSet = new FileMetadataSet();
@@ -1778,7 +1778,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// renamed it's updated with the new filenames.</param>
         /// <returns>Metadata of files in the package indexed by current filename.
         /// The FileMetadataByVersion will be null for files that aren't present in the
-        /// asset database.returns>
+        /// asset database.</returns>
         public Dictionary<string, KeyValuePair<FileMetadata, FileMetadataByVersion>>
                 ParseLegacyManifest(FileMetadata metadata, FileMetadataSet metadataSet) {
             var filesInManifest =
@@ -2090,9 +2090,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         /// <param name="manifestReferencesList">List of manifests to query
         /// for obsolete files.</param>
         /// <param name="metadataSet">Set of metadata to query for obsolete
-        /// files.<param>
-        /// <returns>ObsoleteFiles instance which references the discovered
-        /// obsolete files.</returns>
+        /// files.</param>
         public ObsoleteFiles(
                 List<ManifestReferences> manifestReferencesList,
                 FileMetadataSet metadataSet) {

--- a/source/VersionHandlerImpl/unit_tests/src/EditorMeasurementTest.cs
+++ b/source/VersionHandlerImpl/unit_tests/src/EditorMeasurementTest.cs
@@ -182,7 +182,7 @@ namespace Google.VersionHandlerImpl.Tests {
         /// <summary>
         /// Create a display dialog delegate.
         /// </summary>
-        /// <param name="selectedOption">0..2</param>
+        /// <param name="selectedOptions">0..2</param>
         /// <returns>Display dialog delegate.</returns>
         private DialogWindow.DisplayDelegate CreateDisplayDialogDelegate(
                 List<DialogWindow.Option> selectedOptions) {


### PR DESCRIPTION
Inline code documentation in C# files needs some love.

This PR improves:
- Ensure xml tags are always correctly closed
- Replace `return` tags with `returns` tags
- Fix outdated argument names in inline documentation
- Remove docs for removed arguments
- Add docs for some undocumented arguments
- Fix inline documentation to always starts with exactly three slashes `///`
- Fix regular comments to always starts with `//` and never with `///`
- Replace `<` in xmldoc with `&lt;`
- Fix missing quotes around values of xml attributes
- Ensure `<para>` tag is inside another tag
- Fix documentation on some enumeration values
- Fix few typos