### PR TITLE
Fixes #322, Use the raw property value when the enum does not contain this value

### DIFF
--- a/source/AndroidResolver/src/UnityCompat.cs
+++ b/source/AndroidResolver/src/UnityCompat.cs
@@ -55,11 +55,22 @@ public class UnityCompat {
     }
 
     // Parses a UnityEditor.AndroidSDKVersion enum for a value.
-    private static int VersionFromAndroidSDKVersionsEnum(string enumName, string fallbackPrefKey,
+    private static int VersionFromAndroidSDKVersionsEnum(object enumValue, string fallbackPrefKey,
                                                          int fallbackValue) {
-        // If the enum property has no name it's not possible to parse the version so fallback to
-        // auto-selection.
-        if (String.IsNullOrEmpty(enumName)) return -1;
+        string enumName = null;
+        try {
+            enumName = Enum.GetName(typeof(AndroidSdkVersions), enumValue);
+        }
+        catch (ArgumentException)
+        {
+            //Fall back on auto if the enum value is not parsable
+            return -1;
+        }
+        
+        // If the enumName is empty then enumValue was not represented in the enum, 
+        // most likely because Unity has not yet added the new version,
+        // fall back on the raw enumValue
+        if (String.IsNullOrEmpty(enumName)) return (int)enumValue;
 
         if (enumName.StartsWith(UNITY_ANDROID_VERSION_ENUM_PREFIX)) {
             enumName = enumName.Substring(UNITY_ANDROID_VERSION_ENUM_PREFIX.Length);
@@ -91,7 +102,7 @@ public class UnityCompat {
     /// <returns>the sdk value (ie. 24 for Android 7.0 Nouget)</returns>
     public static int GetAndroidMinSDKVersion() {
         int minSdkVersion = VersionFromAndroidSDKVersionsEnum(
-            PlayerSettings.Android.minSdkVersion.ToString(),
+            (object)PlayerSettings.Android.minSdkVersion,
             ANDROID_MIN_SDK_FALLBACK_KEY, MinSDKVersionFallback);
         if (minSdkVersion == -1)
             return MinSDKVersionFallback;
@@ -121,7 +132,7 @@ public class UnityCompat {
         var property = typeof(UnityEditor.PlayerSettings.Android).GetProperty("targetSdkVersion");
         int apiLevel = property == null ? -1 :
             VersionFromAndroidSDKVersionsEnum(
-                 Enum.GetName(property.PropertyType, property.GetValue(null, null)),
+                 property.GetValue(null, null),
                  ANDROID_PLATFORM_FALLBACK_KEY, AndroidPlatformVersionFallback);
         if (apiLevel >= 0) return apiLevel;
         return FindNewestInstalledAndroidSDKVersion();

--- a/source/AndroidResolver/src/UnityCompat.cs
+++ b/source/AndroidResolver/src/UnityCompat.cs
@@ -60,9 +60,7 @@ public class UnityCompat {
         string enumName = null;
         try {
             enumName = Enum.GetName(typeof(AndroidSdkVersions), enumValue);
-        }
-        catch (ArgumentException)
-        {
+        } catch (ArgumentException) {
             //Fall back on auto if the enum value is not parsable
             return -1;
         }


### PR DESCRIPTION
This fixes #322 where the unity editor will lose its target sdk setting between unity restarts if you have >28 selected in 2019, since unity AndroidSdkVersions enum does not contain values above 28. 

I have no idea why the function for getting the enum value is so roundabout in the first place, perhaps someone could inform me of why we have to go through the enum type and the string name when we have the correct value from the beginning? Are we expecting the enum int values to diverge from the string values at some point? 

I made minimal impact on the function since I don't understand the purpose of it :)