### PR TITLE
Update gradle version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip


### PR DESCRIPTION
I had a repro of googlesamples/unity-jar-resolver#384 with 
 - Unity 2019.2.x 
 - External Dependency Manager 1.2.157
Updating gradle fixes the problem.