### PR TITLE
Disabling update if the module is disabled in the Unity editor;

### DIFF
--- a/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
+++ b/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
@@ -2307,6 +2307,11 @@ public class VersionHandlerImpl : AssetPostprocessor {
     }
 
     static void UpdateVersionedAssetsOnUpdate() {
+        // Skips update if this module is disabled.
+        if (!Enabled) {
+            return;
+        }
+        
         UpdateVersionedAssets();
         NotifyWhenCompliationComplete(false);
         UpdateAssetsWithBuildTargets(EditorUserBuildSettings.activeBuildTarget);


### PR DESCRIPTION
Added this check to avoid un-needed asset database searches on UpdateAssetsWithBuildTargets(EditorUserBuildSettings.activeBuildTarget); This commit solve perfomance issues when working on big projects.