### PR TITLE
Fixing maven repo path separator char

### DIFF
--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -2141,8 +2141,9 @@ namespace GooglePlayServices {
                         // If "Export Gradle Project" setting is enabled, gradle project expects
                         // absolute path.
                         if (exportEnabled) {
-                            repoUri = String.Format("\"{0}\"",
-                                                    Path.Combine(projectFileUri, repoPath));
+                            // build.gradle expects file:/// URI so file separator will be "/" in anycase
+                            // and we must NOT use Path.Combine here because it will use "\" for win platforms
+                            repoUri = String.Format("\"{0}/{1}\"", projectFileUri, repoPath);
                         } else {
                             repoUri = String.Format("(unityProjectPath + \"/{0}\")", repoPath);
                         }


### PR DESCRIPTION
The bug happens only if:
- "Patch mainTemplate.gradle" setting is enabled;
- You are resolving dependencies on Windows platform;

Examples of bad repo path string in mainTemplate.gradle:
file:///C:/Work/UnityProject\Assets/GeneratedLocalRepo/Firebase/m2repository

This happened because Path.Combine uses "\" as path separator for
windows platforms. But gradle actually expects not a regular path
but file URI, where "/" must be used as path separator.