### PR TITLE
Fixed invalid repo path patching & added user setting for path resolution

### DIFF
--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -522,6 +522,16 @@ namespace GooglePlayServices {
             }
         }
 
+        /// <summary>
+        /// Whether the Gradle template should use the relative or absolute path to the local repository.
+        /// Only relevant when <see cref="GradleProjectExportEnabled"/> is also enabled.
+        /// </summary>
+        public static bool UseRelativeRepoPath {
+            get {
+               return SettingsDialogObj.UseRelativeRepoPath;
+            }
+        }
+
         // Backing store for GradleVersion property.
         private static string gradleVersion = null;
         // Extracts a version number from a gradle distribution jar file.
@@ -2106,6 +2116,7 @@ namespace GooglePlayServices {
             var lines = new List<string>();
             if (dependencies.Count > 0) {
                 var exportEnabled = GradleProjectExportEnabled;
+                var useRelativeRepoPath = UseRelativeRepoPath;
                 var projectPath = FileUtils.PosixPathSeparators(Path.GetFullPath("."));
                 var projectFileUri = GradleResolver.RepoPathToUri(projectPath);
                 lines.Add("([rootProject] + (rootProject.subprojects as List)).each { project ->");
@@ -2140,9 +2151,9 @@ namespace GooglePlayServices {
                             repoPath = relativePath;
                         }
 
-                        // If "Export Gradle Project" setting is enabled, gradle project expects
-                        // absolute path.
-                        if (exportEnabled) {
+                        // If "Export Gradle Project" setting is enabled, use absolute path
+                        // unless user has actively opted to use relative path
+                        if (exportEnabled && !useRelativeRepoPath) {
                             repoUri = String.Format("\"{0}\"",
                                                     Path.Combine(projectFileUri, repoPath));
                         } else {
@@ -2486,6 +2497,7 @@ namespace GooglePlayServices {
                 {"explodeAars", SettingsDialogObj.ExplodeAars.ToString()},
                 {"patchAndroidManifest", SettingsDialogObj.PatchAndroidManifest.ToString()},
                 {"patchMainTemplateGradle", SettingsDialogObj.PatchMainTemplateGradle.ToString()},
+                {"useRelativeRepoPath", SettingsDialogObj.UseRelativeRepoPath.ToString()},
                 {"localMavenRepoDir", SettingsDialogObj.LocalMavenRepoDir.ToString()},
                 {"useJetifier", SettingsDialogObj.UseJetifier.ToString()},
                 {"bundleId", GetAndroidApplicationId()},

--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -2155,7 +2155,8 @@ namespace GooglePlayServices {
                         // unless user has actively opted to use relative path
                         if (exportEnabled && !useRelativeRepoPath) {
                             repoUri = String.Format("\"{0}\"",
-                                                    Path.Combine(projectFileUri, repoPath));
+                                                    FileUtils.PosixPathSeparators(
+                                                      Path.Combine(projectFileUri, repoPath)));
                         } else {
                             repoUri = String.Format("(unityProjectPath + \"/{0}\")", repoPath);
                         }

--- a/source/AndroidResolver/src/SettingsDialog.cs
+++ b/source/AndroidResolver/src/SettingsDialog.cs
@@ -38,6 +38,7 @@ namespace GooglePlayServices {
             internal bool explodeAars;
             internal bool patchAndroidManifest;
             internal bool patchMainTemplateGradle;
+            internal bool useRelativeRepoPath;
             internal bool patchPropertiesTemplateGradle;
             internal string localMavenRepoDir;
             internal bool useJetifier;
@@ -59,6 +60,7 @@ namespace GooglePlayServices {
                 explodeAars = SettingsDialog.ExplodeAars;
                 patchAndroidManifest = SettingsDialog.PatchAndroidManifest;
                 patchMainTemplateGradle = SettingsDialog.PatchMainTemplateGradle;
+                useRelativeRepoPath = SettingsDialog.UseRelativeRepoPath;
                 patchPropertiesTemplateGradle = SettingsDialog.PatchPropertiesTemplateGradle;
                 localMavenRepoDir = SettingsDialog.LocalMavenRepoDir;
                 useJetifier = SettingsDialog.UseJetifier;
@@ -81,6 +83,7 @@ namespace GooglePlayServices {
                 SettingsDialog.ExplodeAars = explodeAars;
                 SettingsDialog.PatchAndroidManifest = patchAndroidManifest;
                 SettingsDialog.PatchMainTemplateGradle = patchMainTemplateGradle;
+                SettingsDialog.UseRelativeRepoPath = useRelativeRepoPath;
                 SettingsDialog.PatchPropertiesTemplateGradle = patchPropertiesTemplateGradle;
                 SettingsDialog.LocalMavenRepoDir = localMavenRepoDir;
                 SettingsDialog.UseJetifier = useJetifier;
@@ -100,6 +103,7 @@ namespace GooglePlayServices {
         private const string ExplodeAarsKey = Namespace + "ExplodeAars";
         private const string PatchAndroidManifestKey = Namespace + "PatchAndroidManifest";
         private const string PatchMainTemplateGradleKey = Namespace + "PatchMainTemplateGradle";
+        private const string UseRelativeRepoPathKey = Namespace + "UseRelativeRepoPath";
         private const string PatchPropertiesTemplateGradleKey = Namespace + "PatchPropertiesTemplateGradle";
         private const string LocalMavenRepoDirKey = Namespace + "LocalMavenRepoDir";
         private const string UseJetifierKey = Namespace + "UseJetifier";
@@ -119,6 +123,7 @@ namespace GooglePlayServices {
             ExplodeAarsKey,
             PatchAndroidManifestKey,
             PatchMainTemplateGradleKey,
+            UseRelativeRepoPathKey,
             PatchPropertiesTemplateGradleKey,
             LocalMavenRepoDirKey,
             UseJetifierKey,
@@ -238,6 +243,11 @@ namespace GooglePlayServices {
         internal static bool PatchMainTemplateGradle {
             set { projectSettings.SetBool(PatchMainTemplateGradleKey, value); }
             get { return projectSettings.GetBool(PatchMainTemplateGradleKey, true); }
+        }
+
+        internal static bool UseRelativeRepoPath {
+            set { projectSettings.SetBool(UseRelativeRepoPathKey, value); }
+            get { return projectSettings.GetBool(UseRelativeRepoPathKey, false); }
         }
 
         internal static bool PatchPropertiesTemplateGradle {
@@ -500,6 +510,27 @@ namespace GooglePlayServices {
                 settings.localMavenRepoDir = FileUtils.PosixPathSeparators(
                         ValidateLocalMavenRepoDir(EditorGUILayout.TextField(
                                 settings.localMavenRepoDir)));
+            }
+
+            if (settings.patchMainTemplateGradle) {
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Use relative repository path", EditorStyles.boldLabel);
+                settings.useRelativeRepoPath =
+                    EditorGUILayout.Toggle(settings.useRelativeRepoPath);
+                GUILayout.EndHorizontal();
+
+                if (settings.useRelativeRepoPath) {
+                    GUILayout.Label(
+                        "The mainTemplate.gradle file will be patched with a relative path to " +
+                        "the Local Maven Repository. This can be used to limit file changes when " +
+                        "the template is versioned, but the exported project will not work if relocated " +
+                        "after building.");
+                } else {
+                    GUILayout.Label(
+                        "The mainTemplate.gradle file will be patched with an absolute path to " +
+                        "the Local Maven Repository. This ensures that the exported project can be " +
+                        "relocated anywhere after building.");
+                }
             }
 
             GUILayout.BeginHorizontal();

--- a/source/AndroidResolver/src/SettingsDialog.cs
+++ b/source/AndroidResolver/src/SettingsDialog.cs
@@ -245,6 +245,7 @@ namespace GooglePlayServices {
             get { return projectSettings.GetBool(PatchMainTemplateGradleKey, true); }
         }
 
+        // TODO: Please add integration test for this flag.
         internal static bool UseRelativeRepoPath {
             set { projectSettings.SetBool(UseRelativeRepoPathKey, value); }
             get { return projectSettings.GetBool(UseRelativeRepoPathKey, false); }

--- a/source/AndroidResolver/src/SettingsDialog.cs
+++ b/source/AndroidResolver/src/SettingsDialog.cs
@@ -522,9 +522,9 @@ namespace GooglePlayServices {
                 if (settings.useRelativeRepoPath) {
                     GUILayout.Label(
                         "The mainTemplate.gradle file will be patched with a relative path to " +
-                        "the Local Maven Repository. This can be used to limit file changes when " +
-                        "the template is versioned, but the exported project will not work if relocated " +
-                        "after building.");
+                        "the Local Maven Repository for an exported Android project. This can be used " +
+                        "to limit file changes when the template is versioned, but the exported " +
+                        "project will not work if relocated after building.");
                 } else {
                     GUILayout.Label(
                         "The mainTemplate.gradle file will be patched with an absolute path to " +


### PR DESCRIPTION
This fixes #426 where paths would be combined incorrectly on Windows (used backslash when forward slash is expected).

As discussed in the comments, I also added a user setting "Use relative repository path":
![image](https://user-images.githubusercontent.com/6575922/118139209-6c51c100-b407-11eb-952f-855eca8ff189.png)

The value defaults to `false` to preserve existing behavior.