### PR TITLE
Fix Dependency.cs IsGreater() detection of + characters on version2 string

### DIFF
--- a/source/JarResolverLib/src/Google.JarResolver/Dependency.cs
+++ b/source/JarResolverLib/src/Google.JarResolver/Dependency.cs
@@ -193,7 +193,7 @@ namespace Google.JarResolver {
         private static bool IsGreater(string version1, string version2) {
             version1 = version1.EndsWith("+") ?
                 version1.Substring(0, version1.Length - 1) : version1;
-            version2 = version1.EndsWith("+") ?
+            version2 = version2.EndsWith("+") ?
                 version2.Substring(0, version2.Length - 1) : version2;
             string[] version1Components = version1.Split('.');
             string[] version2Components = version2.Split('.');


### PR DESCRIPTION
Fix for issue #442. 

Dependnecy.cs was using `version1` string to detect a '+' suffix for the `version2` string in the `IsGreater` method.