### PR TITLE
Fix for #447

### DIFF
--- a/source/AndroidResolver/src/UnityCompat.cs
+++ b/source/AndroidResolver/src/UnityCompat.cs
@@ -444,7 +444,7 @@ public class UnityCompat {
     /// <returns>Application identifier if it can be retrieved, null otherwise.</returns>
     private static string GetUnity56AndAboveApplicationIdentifier(BuildTarget buildTarget) {
         var getApplicationIdentifierMethod =
-            typeof(UnityEditor.PlayerSettings).GetMethod("GetApplicationIdentifier");
+            typeof(UnityEditor.PlayerSettings).GetMethod("GetApplicationIdentifier", new[]{typeof(BuildTargetGroup)});
         if (getApplicationIdentifierMethod == null) return null;
         var buildTargetGroup = ConvertBuildTargetToBuildTargetGroup(buildTarget);
         if (buildTargetGroup == BuildTargetGroup.Unknown) return null;


### PR DESCRIPTION
Fixed the call to GetMethod for GetApplicationIdentifier so that the method lookup is no longer ambiguous in Unity 2021.2