### PR TITLE
Unity now supports x86_64 for Android apps on Chrome OS. Add it to th…

### DIFF
--- a/source/AndroidResolver/src/AndroidAbis.cs
+++ b/source/AndroidResolver/src/AndroidAbis.cs
@@ -240,6 +240,7 @@ internal class AndroidAbis {
 
     /// <summary>
     /// Get / set the target device ABI (Unity >= 5.0.x)
+    /// Unity >= 2019.4 supports armeabi-v7a, arm64-v8a, x86, x86_64 & fat (i.e armeabi-v7a, arm64, x86, x86_64)
     /// Unity >= 2017.4 supports armeabi-v7a, arm64-v8a, x86 & fat (i.e armeabi-v7a, arm64, x86)
     /// Unity >= 5.0.x & &lt;= 2017.3 only support armeabi-v7a, x86 & fat (i.e armeabi-v7a & x86)
     /// </summary>

--- a/source/AndroidResolver/src/AndroidAbis.cs
+++ b/source/AndroidResolver/src/AndroidAbis.cs
@@ -34,7 +34,7 @@ internal class AndroidAbis {
         public enum Mode {
             FatOnly, // Only supports fat (armeabi-v7a & x86) builds.
             OneOfArmX86Fat, // Supports one of armeabi-v7a, x86 or fat builds.
-            AnyOfArmX86Arm64, // Supports any combination of armeabi-v7a, x86 or arm64 builds.
+            AnyOfArmX86Arm64, // Supports any combination of armeabi-v7a, x86, x86_64 or arm64 builds.
         }
 
         /// <summary>
@@ -74,7 +74,8 @@ internal class AndroidAbis {
                 foreach (var abi in new Dictionary<string, string>() {
                              {"armeabi-v7a", "ARMv7"},
                              {"arm64-v8a", "ARM64"},
-                             {"x86", "X86"}
+                             {"x86", "X86"},
+                             {"x86_64", "X86_64"}
                          }) {
                     try {
                         EnumValueStringToULong(EnumType, abi.Value);


### PR DESCRIPTION
To resolve issue #461. x86_64 support for Android projects.