### PR TITLE
Move versioned dlls to be under a version folder (Fix #441)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -290,6 +290,8 @@ project.ext {
   pipExe = new File(pythonBinDir, "pip3")
   // Python packages required by export_unity_package.py
   exportUnityPackageRequirements = ["absl-py", "PyYAML"]
+  // Python packages required by gen_guids.py
+  genGuidRequirements = ["absl-py"]
 }
 
 // Configure com.jetbrains.python.envs to bootstrap a Python install.
@@ -485,11 +487,13 @@ List<String> splitFilenameExtension(File fileObj) {
  * @param fileObj File to add version to.
  * @param fullVersionPrefix if true uses the "_version-" otherwise uses "_v-".
  * @param postfix Optional string to add before the extensioon.
+ * @param useVersionDir If true, place the file to be under a folder named after
+ *        the version number, instead of changing the filename.
  *
  * @returns File which includes an encoded version.
  */
 File versionedAssetFile(File fileObj, Boolean fullVersionPrefix,
-                        String postfix) {
+                        String postfix, Boolean useVersionDir) {
   String basename
   String extension
   (basename, extension) = splitFilenameExtension(fileObj)
@@ -497,12 +501,17 @@ File versionedAssetFile(File fileObj, Boolean fullVersionPrefix,
   // ${dllname}_version-${version}.dll
   String targetName = basename
   String version = project.ext.pluginVersion
+  File dllDir = fileObj.parent != null ? new File(fileObj.parent) :
+        new File()
   if (!(version == null || version.isEmpty())) {
-    targetName += (fullVersionPrefix ? "_version-" : "_v") + version
+    if (useVersionDir) {
+      dllDir = new File(dllDir, version)
+    } else {
+      targetName += (fullVersionPrefix ? "_version-" : "_v") + version
+    }
   }
   String filename = targetName + postfix + extension
-  return fileObj.parent != null ? new File(fileObj.parent, filename) :
-    new File(filename)
+  return new File(dllDir, filename)
 }
 
 /*
@@ -636,7 +645,8 @@ File copyAssetMetadataFile(File sourceFile, File targetFile) {
       def guidMatch = (line =~ /^(guid:)\s+(.*)/)
       def versionLabelMatch = (line =~ versionRegEx)
       def exportPathMatch = (line =~ exportPathRegEx)
-      if (guidMatch.matches() && sourceFile.name != targetFile.name) {
+      if (guidMatch.matches() && (sourceFile.name != targetFile.name ||
+            sourceFile.parent != targetFile.parent ) ) {
         // Update the metadata's GUID.
         // If a file is renamed we want to make sure Unity imports it as a new
         // asset with the new filename.
@@ -821,7 +831,7 @@ Task createBuildPluginDllTask(String componentName,
       return [
         unversionedFile.path,
         versionDll ?
-          versionedAssetFile(unversionedOutputFile, false, "") :
+          versionedAssetFile(unversionedOutputFile, false, "", true) :
           unversionedOutputFile]
     }
 
@@ -1320,6 +1330,30 @@ Task createExportUnityPackageTask(String taskName,
   return exportUnityPackageTask
 }
 
+Task createGenGuidTask(String taskName,
+                       String description,
+                       File guidsFile,
+                       String pluginVersion,
+                       Iterable<String> guidPath) {
+  File genGuidScript = new File(project.ext.exportUnityPackageDir,
+                               "gen_guids.py")
+  Task genGuidTask = createPythonTask(
+    taskName,
+    description,
+    [],
+    genGuidScript,
+    ["--version", pluginVersion,
+     "--guids_file", guidsFile] +
+    guidPath,
+    genGuidRequirements)
+  genGuidTask.with {
+    inputs.files ([guidsFile] +
+                  [genGuidScript])
+  }
+  return genGuidTask
+}
+
+
 Task testResolverLibTests = createNUnitTask(
   "testResolverLibTests",
   "Runs the tests for the deprecated Jar Resolver library",
@@ -1487,9 +1521,15 @@ task generatePluginManifest(dependsOn: [preparePluginStagingAreaDir,
                       project.ext.pluginEditorDllDir.path),
              unversionedManifestName + project.ext.unityMetadataExtension)
   File manifestFile = versionedAssetFile(
-    new File(outputDir, unversionedManifestName), true, "_manifest")
+    new File(outputDir, unversionedManifestName),
+    true,
+    "_manifest",
+    false)
   File manifestMetadataFile = versionedAssetFile(
-    new File(outputDir, manifestMetadataTemplateFile.name), true, "_manifest")
+    new File(outputDir, manifestMetadataTemplateFile.name),
+    true,
+    "_manifest",
+    false)
 
   description "Generate a manifest for the files in the plug-in."
   inputs.files files(manifestMetadataTemplateFile)
@@ -1549,10 +1589,24 @@ buildPlugin.with {
   outputs.files project.ext.pluginExportFile.absolutePath
 }
 
+// Guid paths for UPM package.
+File upmPluginPackageDir = new File("com.google.external-dependency-manager",
+    "ExternalDependencyManager")
+File upmPluginEditorDir = new File(upmPluginPackageDir, "Editor")
+File upmPluginDllDir = new File(upmPluginEditorDir, project.ext.pluginVersion)
+
+Task genGuidUpm = createGenGuidTask(
+  "genGuidUpm",
+  "Generate GUID for .tgz packaging.",
+  new File(project.ext.scriptDirectory, "export_unity_package_guids.json"),
+  project.ext.pluginVersion,
+  [upmPluginDllDir.path]
+)
+
 Task buildUpmPlugin = createExportUnityPackageTask(
   "buildUpmPlugin",
-  "Package the .unitypackage with export_unity_package.py.",
-  [generatePluginManifest],
+  "Package the .tgz with export_unity_package.py.",
+  [generatePluginManifest, genGuidUpm],
   new File(project.ext.scriptDirectory, "export_unity_package_config.json"),
   new File(project.ext.scriptDirectory, "export_unity_package_guids.json"),
   new File(project.ext.pluginStagingAreaDir, "Assets"),

--- a/build.gradle
+++ b/build.gradle
@@ -296,7 +296,7 @@ project.ext {
 envs {
   bootstrapDirectory = project.ext.pythonBootstrapDir
   envsDirectory = new File(project.ext.buildDir, "python_envs")
-  python "python", "3.9.3"
+  python "python", "3.9.5"
 }
 
 /*

--- a/export_unity_package_config.json
+++ b/export_unity_package_config.json
@@ -15,10 +15,10 @@
           "platforms": [],
           "labels": ["gvhp_targets-editor"],
           "paths": [
-            "ExternalDependencyManager/Editor/Google.IOSResolver_*.*",
-            "ExternalDependencyManager/Editor/Google.JarResolver_*.*",
-            "ExternalDependencyManager/Editor/Google.VersionHandlerImpl_*.*",
-            "ExternalDependencyManager/Editor/Google.PackageManagerResolver_*.*"
+            "ExternalDependencyManager/Editor/*/Google.IOSResolver.*",
+            "ExternalDependencyManager/Editor/*/Google.JarResolver.*",
+            "ExternalDependencyManager/Editor/*/Google.VersionHandlerImpl.*",
+            "ExternalDependencyManager/Editor/*/Google.PackageManagerResolver.*"
           ],
           "override_metadata_upm": {
             "PluginImporter": {

--- a/export_unity_package_guids.json
+++ b/export_unity_package_guids.json
@@ -1,10 +1,13 @@
 {
     "1.2.137": {
+        "com.google.external-dependency-manager/CHANGELOG.md": "dd6a29a412594aadb37d9698db325eca",
         "com.google.external-dependency-manager/ExternalDependencyManager": "46f5870ddbde4a6091f50656dcd5573e",
         "com.google.external-dependency-manager/ExternalDependencyManager/Editor": "1f23cd25474841f6ad7555705b4807e9",
-        "com.google.external-dependency-manager/package.json": "9bed450d5c03481d87e61b61431cf00a",
-        "com.google.external-dependency-manager/CHANGELOG.md": "dd6a29a412594aadb37d9698db325eca",
         "com.google.external-dependency-manager/LICENSE.md": "f61a1c8e753b496bb696e77d7eedfb95",
-        "com.google.external-dependency-manager/README.md": "cbbebcaa6ecb4b9582dce440a386de75"
+        "com.google.external-dependency-manager/README.md": "cbbebcaa6ecb4b9582dce440a386de75",
+        "com.google.external-dependency-manager/package.json": "9bed450d5c03481d87e61b61431cf00a"
+    },
+    "1.2.166": {
+        "com.google.external-dependency-manager/ExternalDependencyManager/Editor/1.2.166": "9dfec94683154487ab08de0c50179674"
     }
 }


### PR DESCRIPTION
Move the versioned dlls such as `IOSResolver.dll` to be under a version folder instead of using version postfix like `_v1.2.166`

This is a workaround for Unity 2021.1.11+ not loading `IOSResolver_v1.2.166.dll` because the filename does not match the assembly.