### PR TITLE
Properly enable EDM4U for Unity 2021.2. Fixed #477

### DIFF
--- a/export_unity_package_config.json
+++ b/export_unity_package_config.json
@@ -22,11 +22,15 @@
           ],
           "override_metadata_upm": {
             "PluginImporter": {
-              "platformData": {
-                "Editor": {
-                  "enabled": 1
+              "platformData": [ {
+                  "first" : {
+                      "Editor": "Editor"
+                  },
+                  "second": {
+                      "enabled": 1
+                  }
                 }
-              }
+              ]
             }
           }
         },


### PR DESCRIPTION
Update `.meta` for editor libraries used in `.tgz` so that Unity 2021.2+ can properly load them.

This change the `export.json` config so that the export tool can properly override `.meta` file during package time.

The export tool will 
1. Use the `.meta` template here. https://github.com/googlesamples/unity-jar-resolver/blob/master/plugin/Assets/ExternalDependencyManager/Editor/Google.IOSResolver.dll.meta
2. Override the `.meta` while packaging `.tgz` based on the `override_metadata_upm` field. 

The `.meta` for `.unitypackage` will remain unchanged.