### PR TITLE
Change default value of PodToolExecutionViaShellEnabled to be compatible with CocoaPods 11.

### DIFF
--- a/source/AndroidResolver/src/CommandLine.cs
+++ b/source/AndroidResolver/src/CommandLine.cs
@@ -535,6 +535,8 @@ namespace GooglePlayServices
         /// executing a command via the shell.  This requires:
         /// * cmd.exe (on Windows) or bash (on OSX / Linux) are in the path.
         /// * Arguments containing whitespace are quoted.</param>
+        /// <param name="setLangInShellMode">Causes environment variable LANG to be explicitly set
+        /// when  executing a command via the shell.  This is only applicable to OSX.</param>
         /// <returns>CommandLineTool result if successful, raises an exception if it's not
         /// possible to execute the tool.</returns>
         public static Result RunViaShell(

--- a/source/AndroidResolver/src/CommandLine.cs
+++ b/source/AndroidResolver/src/CommandLine.cs
@@ -541,7 +541,7 @@ namespace GooglePlayServices
                 string toolPath, string arguments, string workingDirectory = null,
                 Dictionary<string, string> envVars = null,
                 IOHandler ioHandler = null, bool useShellExecution = false,
-                bool stdoutRedirectionInShellMode = true) {
+                bool stdoutRedirectionInShellMode = true, bool setLangInShellMode = false) {
             bool consoleConfigurationWarning = false;
             Encoding inputEncoding = Console.InputEncoding;
             Encoding outputEncoding = Console.OutputEncoding;
@@ -591,6 +591,7 @@ namespace GooglePlayServices
                 string shellArgPrefix;
                 string shellArgPostfix;
                 string escapedToolPath = toolPath;
+                string additionalCommands = "";
                 if (UnityEngine.RuntimePlatform.WindowsEditor == UnityEngine.Application.platform) {
                     shellCmd = "cmd.exe";
                     shellArgPrefix = "/c \"";
@@ -600,9 +601,13 @@ namespace GooglePlayServices
                     shellArgPrefix = "-l -c '";
                     shellArgPostfix = "'";
                     escapedToolPath = toolPath.Replace("'", "'\\''");
+                    if (UnityEngine.RuntimePlatform.OSXEditor == UnityEngine.Application.platform
+                            && envVars != null && envVars.ContainsKey("LANG") && setLangInShellMode) {
+                        additionalCommands = String.Format("export {0}={1}; ", "LANG", envVars["LANG"]);
+                    }
                 }
-                arguments = String.Format("{0}\"{1}\" {2} 1> {3} 2> {4}{5}", shellArgPrefix,
-                                          escapedToolPath, arguments, stdoutFileName,
+                arguments = String.Format("{0}{1}\"{2}\" {3} 1> {4} 2> {5}{6}", shellArgPrefix,
+                                          additionalCommands, escapedToolPath, arguments, stdoutFileName,
                                           stderrFileName, shellArgPostfix);
                 toolPath = shellCmd;
             }

--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -462,6 +462,9 @@ public class IOSResolver : AssetPostprocessor {
     // Whether execution of the pod tool is performed via the shell.
     private const string PREFERENCE_POD_TOOL_EXECUTION_VIA_SHELL_ENABLED =
         PREFERENCE_NAMESPACE + "PodToolExecutionViaShellEnabled";
+    // Whether environment variables should be set when execution is performed via the shell.
+    private const string PREFERENCE_POD_TOOL_SHELL_EXECUTION_SET_LANG =
+        PREFERENCE_NAMESPACE + "PodToolShellExecutionSetLang";
     // Whether to try to install Cocoapods tools when iOS is selected as the target platform.
     private const string PREFERENCE_AUTO_POD_TOOL_INSTALL_IN_EDITOR =
         PREFERENCE_NAMESPACE + "AutoPodToolInstallInEditor";
@@ -955,8 +958,17 @@ public class IOSResolver : AssetPostprocessor {
     /// </summary>
     public static bool PodToolExecutionViaShellEnabled {
         get { return settings.GetBool(PREFERENCE_POD_TOOL_EXECUTION_VIA_SHELL_ENABLED,
-                                      defaultValue: false); }
+                                      defaultValue: true); }
         set { settings.SetBool(PREFERENCE_POD_TOOL_EXECUTION_VIA_SHELL_ENABLED, value); }
+    }
+
+    /// <summary>
+    /// Enable / disable setting of environment variables when executing pod tool via the shell.
+    /// </summary>
+    public static bool PodToolShellExecutionSetLang {
+        get { return settings.GetBool(PREFERENCE_POD_TOOL_SHELL_EXECUTION_SET_LANG,
+                                      defaultValue: true); }
+        set { settings.SetBool(PREFERENCE_POD_TOOL_SHELL_EXECUTION_SET_LANG, value); }
     }
 
     /// <summary>
@@ -2383,7 +2395,8 @@ public class IOSResolver : AssetPostprocessor {
                 Log(command.ToString(), verbose: true);
                 var result = CommandLine.RunViaShell(
                     command.Command, command.Arguments, workingDirectory: command.WorkingDirectory,
-                    envVars: envVars, useShellExecution: PodToolExecutionViaShellEnabled);
+                    envVars: envVars, useShellExecution: PodToolExecutionViaShellEnabled,
+                    setLangInShellMode: PodToolShellExecutionSetLang);
                 LogCommandLineResult(command.ToString(), result);
                 index = completionDelegate(index, commands, result, null);
             }

--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -955,7 +955,7 @@ public class IOSResolver : AssetPostprocessor {
     /// </summary>
     public static bool PodToolExecutionViaShellEnabled {
         get { return settings.GetBool(PREFERENCE_POD_TOOL_EXECUTION_VIA_SHELL_ENABLED,
-                                      defaultValue: true); }
+                                      defaultValue: false); }
         set { settings.SetBool(PREFERENCE_POD_TOOL_EXECUTION_VIA_SHELL_ENABLED, value); }
     }
 

--- a/source/IOSResolver/src/IOSResolverSettingsDialog.cs
+++ b/source/IOSResolver/src/IOSResolverSettingsDialog.cs
@@ -33,6 +33,7 @@ public class IOSResolverSettingsDialog : EditorWindow
     private class Settings {
         internal bool podfileGenerationEnabled;
         internal bool podToolExecutionViaShellEnabled;
+        internal bool podToolShellExecutionSetLang;
         internal bool autoPodToolInstallInEditorEnabled;
         internal bool verboseLoggingEnabled;
         internal int cocoapodsIntegrationMenuIndex;
@@ -49,6 +50,7 @@ public class IOSResolverSettingsDialog : EditorWindow
         internal Settings() {
             podfileGenerationEnabled = IOSResolver.PodfileGenerationEnabled;
             podToolExecutionViaShellEnabled = IOSResolver.PodToolExecutionViaShellEnabled;
+            podToolShellExecutionSetLang = IOSResolver.PodToolShellExecutionSetLang;
             autoPodToolInstallInEditorEnabled = IOSResolver.AutoPodToolInstallInEditorEnabled;
             verboseLoggingEnabled = IOSResolver.VerboseLoggingEnabled;
             cocoapodsIntegrationMenuIndex = FindIndexFromCocoapodsIntegrationMethod(
@@ -67,6 +69,7 @@ public class IOSResolverSettingsDialog : EditorWindow
         internal void Save() {
             IOSResolver.PodfileGenerationEnabled = podfileGenerationEnabled;
             IOSResolver.PodToolExecutionViaShellEnabled = podToolExecutionViaShellEnabled;
+            IOSResolver.PodToolShellExecutionSetLang = podToolShellExecutionSetLang;
             IOSResolver.AutoPodToolInstallInEditorEnabled = autoPodToolInstallInEditorEnabled;
             IOSResolver.VerboseLoggingEnabled = verboseLoggingEnabled;
             IOSResolver.CocoapodsIntegrationMethodPref =
@@ -107,7 +110,7 @@ public class IOSResolverSettingsDialog : EditorWindow
     }
 
     public void Initialize() {
-        minSize = new Vector2(400, 700);
+        minSize = new Vector2(400, 715);
         position = new Rect(UnityEngine.Screen.width / 3, UnityEngine.Screen.height / 3,
                             minSize.x, minSize.y);
     }
@@ -168,9 +171,16 @@ public class IOSResolverSettingsDialog : EditorWindow
         settings.podToolExecutionViaShellEnabled =
             EditorGUILayout.Toggle(settings.podToolExecutionViaShellEnabled);
         GUILayout.EndHorizontal();
+        GUILayout.Label("Shell execution is useful when configuration in the shell " +
+                        "environment (e.g ~/.profile) is required to execute Cocoapods tools.");
+
         if (settings.podToolExecutionViaShellEnabled) {
-            GUILayout.Label("Shell execution is useful when configuration in the shell " +
-                            "environment (e.g ~/.profile) is required to execute Cocoapods tools.");
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Set LANG When Using Shell to Execute Cocoapod Tool", EditorStyles.boldLabel);
+            settings.podToolShellExecutionSetLang =
+                EditorGUILayout.Toggle(settings.podToolShellExecutionSetLang);
+            GUILayout.EndHorizontal();
+            GUILayout.Label("Useful for versions of cocoapods that depend on the value of LANG.");
         }
 
         GUILayout.BeginHorizontal();
@@ -280,6 +290,9 @@ public class IOSResolverSettingsDialog : EditorWindow
                     new KeyValuePair<string, string>(
                         "podToolExecutionViaShellEnabled",
                         IOSResolver.PodToolExecutionViaShellEnabled.ToString()),
+                    new KeyValuePair<string, string>(
+                        "podToolShellExecutionSetLang",
+                        IOSResolver.PodToolShellExecutionSetLang.ToString()),
                     new KeyValuePair<string, string>(
                         "autoPodToolInstallInEditorEnabled",
                         IOSResolver.AutoPodToolInstallInEditorEnabled.ToString()),


### PR DESCRIPTION
Change default value of PodToolExecutionViaShellEnabled from true to false.
When shell execution is disabled, environment variables can be set explicitly for the cocoapods process instead of relying on the user's bash profile. This guarantees that LANG is set to a value that includes utf8, which is necessary when using CocoaPods version 1.11 or higher.

This resolves https://github.com/firebase/quickstart-unity/issues/1149