### PR TITLE
Fixes #425 - Disable addition of BoM for the GvhProjectSettings

### DIFF
--- a/source/VersionHandlerImpl/src/ProjectSettings.cs
+++ b/source/VersionHandlerImpl/src/ProjectSettings.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Xml;
 using UnityEditor;
 
@@ -820,6 +821,7 @@ namespace Google {
                     using (var writer =
                            XmlWriter.Create(PROJECT_SETTINGS_FILE,
                                             new XmlWriterSettings {
+                                                Encoding = new UTF8Encoding(false),
                                                 Indent = true,
                                                 IndentChars = "  ",
                                                 NewLineChars = "\n",


### PR DESCRIPTION
See https://github.com/googlesamples/unity-jar-resolver/issues/425
This fixes the problem for git fighting with the BoM.
From the [Microsoft documentation](https://docs.microsoft.com/en-us/dotnet/api/system.xml.xmlwriter.create?view=net-6.0):

> Remarks
> 
> XmlWriter always writes a Byte Order Mark (BOM) to the underlying data stream; however, some streams must not have a BOM. To omit the BOM, create a new XmlWriterSettings object and set the Encoding property to be a new UTF8Encoding object with the Boolean value in the constructor set to false.