### PR TITLE
Swap jcenter and mavenCentral order

### DIFF
--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -2166,8 +2166,8 @@ namespace GooglePlayServices {
                 }
 
                 lines.Add("        mavenLocal()");
-                lines.Add("        jcenter()");
                 lines.Add("        mavenCentral()");
+                lines.Add("        jcenter()");
                 lines.Add("    }");
                 lines.Add("}");
             }


### PR DESCRIPTION
The jcenter is a Read-Only repository nowadays, and hence we should only use it only as a last resource.
You can learn more about the jcenter deprecation here: https://developer.android.com/studio/build/jcenter-migration