### PR TITLE
Speed up iOS resolver by 10-15 minutes

### DIFF
--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -77,7 +77,7 @@ public class IOSResolver : AssetPostprocessor {
         /// See: https://guides.cocoapods.org/syntax/podfile.html#source
         /// </summary>
         public List<string> sources = new List<string>() {
-            "https://github.com/CocoaPods/Specs.git"
+            "https://cdn.cocoapods.org/"
         };
 
         /// <summary>


### PR DESCRIPTION
CocoaPods has [introduced their CDN in 2019](https://blog.cocoapods.org/CocoaPods-1.8.0-beta/) and made it the default source. EDM's iOS resolver explicitly specifies the old source which has become extremely slow. The old source takes 10-15 minutes to clone on our build agents, making iOS builds needlessly slow. Using the CDN allows us to skip this step and start resolving dependencies right away.

This isn't obvious in local development because it only happens once and gets cached in `~/.cocoapods`, but disposable build agents have to run it with every single build. Caching the repo is slow because it's around a gigabyte and contains over one million files.

Resolves #470.