### PR TITLE
`Enable Swift Framework Support Workaround` ON by default

### DIFF
--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -1054,7 +1054,7 @@ public class IOSResolver : AssetPostprocessor {
     /// </summary>
     public static bool SwiftFrameworkSupportWorkaroundEnabled {
         get { return settings.GetBool(PREFERENCE_SWIFT_FRAMEWORK_SUPPORT_WORKAROUND,
-                                    defaultValue: false); }
+                                    defaultValue: true); }
         set {
             settings.SetBool(PREFERENCE_SWIFT_FRAMEWORK_SUPPORT_WORKAROUND, value);
         }

--- a/source/IOSResolver/src/IOSResolverSettingsDialog.cs
+++ b/source/IOSResolver/src/IOSResolverSettingsDialog.cs
@@ -264,7 +264,7 @@ public class IOSResolverSettingsDialog : EditorWindow
 
             if (settings.podfileAddUseFrameworks) {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label("Enable Swift Framework Support Workaround",
+                GUILayout.Label("(Recommended) Enable Swift Framework Support Workaround",
                     EditorStyles.boldLabel);
                 settings.swiftFrameworkSupportWorkaroundEnabled =
                     EditorGUILayout.Toggle(settings.swiftFrameworkSupportWorkaroundEnabled);


### PR DESCRIPTION
As more pods starting to use Swift Framework, this option is turned ON by default now.