### PR TITLE
Remove the Always embed swift libraries flag

### DIFF
--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -2016,7 +2016,6 @@ public class IOSResolver : AssetPostprocessor {
             // generated from 2019.3+.
             if(MultipleXcodeTargetsSupported) {
                 project.SetBuildProperty(target, "CLANG_ENABLE_MODULES", "YES");
-                project.SetBuildProperty(target, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "YES");
             }
         }
 


### PR DESCRIPTION
As part of enabled swift, we had forced ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to YES, but that should not be necessary, as we also add an empty swift file to the target, which will enable swift. On top of that, the always embed flag seems to cause problems for some when submitting apps because of the additional framework folder it might make.

See:
https://github.com/firebase/firebase-unity-sdk/issues/349
and
https://github.com/googleads/googleads-mobile-unity/issues/2065
