### PR TITLE
add tvOS structures to export_unity_package.py

### DIFF
--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -72,6 +72,7 @@ The json file should have the following format:
                     #    platforms including the editor.
                     # * Android
                     # * iOS
+                    # * tvOS
                     "platforms": ["Editor", "Standalone", "Android", "iOS"],
 
                     # CPUs supported by standalone or editor platforms when the

--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -404,6 +404,12 @@ DEFAULT_PLATFORM_SETTINGS_DISABLED_IOS = collections.OrderedDict(
         [("CompileFlags", None),
          ("FrameworkDependencies", None)]))])
 
+DEFAULT_PLATFORM_SETTINGS_DISABLED_TVOS = collections.OrderedDict(
+    PLATFORM_SETTINGS_DISABLED +
+    [("settings", collections.OrderedDict(
+        [("CompileFlags", None),
+         ("FrameworkDependencies", None)]))])
+
 PLUGIN_IMPORTER_METADATA_TEMPLATE = collections.OrderedDict(
     [("PluginImporter", collections.OrderedDict(
         [("serializedVersion", 1),
@@ -441,6 +447,8 @@ PLUGIN_IMPORTER_METADATA_TEMPLATE = collections.OrderedDict(
                   DEFAULT_PLATFORM_SETTINGS_DISABLED)),
               ("iOS", copy.deepcopy(
                   DEFAULT_PLATFORM_SETTINGS_DISABLED_IOS)),
+              ("tvOS", copy.deepcopy(
+                  DEFAULT_PLATFORM_SETTINGS_DISABLED_TVOS)),
              ]))
         ] + DEFAULT_IMPORTER_DATA))
     ])
@@ -465,6 +473,7 @@ PLATFORM_TARGET_BY_PLATFORM = {
     "Win64": "Standalone",
     "WindowsStoreApps": "Windows Store Apps",
     "iOS": "iPhone",
+    "tvOS": "tvOS",
 }
 
 # Alias for standalone platforms specified by the keys of
@@ -1755,6 +1764,7 @@ class AssetConfiguration(ConfigurationBlock):
     elif importer_type == "PluginImporter":
       platforms = set(safe_dict_get_value(
           self._json, "platforms", default_value=["Editor", "Android", "iOS",
+                                                  "tvOS",
                                                   STANDALONE_PLATFORM_ALIAS]))
       cpu_string = safe_dict_get_value(self._json, "cpu",
                                        default_value="AnyCPU")

--- a/source/ExportUnityPackage/export_unity_package_test.py
+++ b/source/ExportUnityPackage/export_unity_package_test.py
@@ -1678,6 +1678,7 @@ class AssetTest(absltest.TestCase):
     del platform_data["Win64"]
     del platform_data["WindowsStoreApps"]
     del platform_data["iOS"]
+    del platform_data["tvOS"]
 
     expected_metadata = copy.deepcopy(
         export_unity_package.PLUGIN_IMPORTER_METADATA_TEMPLATE)
@@ -1697,6 +1698,7 @@ class AssetTest(absltest.TestCase):
     platform_data["Win64"]["enabled"] = 1
     platform_data["WindowsStoreApps"]["enabled"] = 1
     platform_data["iOS"]["enabled"] = 1
+    platform_data["tvOS"]["enabled"] = 1
 
     all_platforms_enabled = (
         export_unity_package.Asset.apply_any_platform_selection(
@@ -2050,6 +2052,15 @@ class AssetConfigurationTest(absltest.TestCase):
         export_unity_package.AssetConfiguration(
             self.package, {"importer": "PluginImporter",
                            "platforms": ["iOS"]}).importer_metadata)
+
+  def test_importer_metadata_tvos_only(self):
+    """Create metadata that only targets tvOS."""
+    self.plugin_metadata["PluginImporter"]["platformData"]["tvOS"]["enabled"] = 1
+    self.assertEqual(
+        self.plugin_metadata,
+        export_unity_package.AssetConfiguration(
+            self.package, {"importer": "PluginImporter",
+                           "platforms": ["tvOS"]}).importer_metadata)
 
   def test_importer_metadata_standalone_invalid_cpu(self):
     """Create metadata with an invalid CPU."""


### PR DESCRIPTION
Update `export_unity_package.py` with the ability to handle `tvOS` build targets.