### PR TITLE
Workaroud when `AssetDatabase.CreateFolder` failed

### DIFF
--- a/source/VersionHandlerImpl/src/FileUtils.cs
+++ b/source/VersionHandlerImpl/src/FileUtils.cs
@@ -53,11 +53,6 @@ namespace Google {
                 new Regex(@"^(Library[/\\]PackageCache[/\\])([^/\\]+)(@[^/\\]+)[/\\](.*)?$");
 
         /// <summary>
-        /// Regex to match invalid GUID like "00000000-0000-0000-0000-000000000000" or "00000000000000000000000000000000"
-        /// </summary>
-        private static Regex ZERO_GUID_REGEX = new Regex(@"^[0-]+$");
-
-        /// <summary>
         /// Returns the project directory (e.g contains the Assets folder).
         /// </summary>
         /// <returns>Full path to the project directory.</returns>

--- a/source/VersionHandlerImpl/unit_tests/src/FileUtilsTest.cs
+++ b/source/VersionHandlerImpl/unit_tests/src/FileUtilsTest.cs
@@ -391,5 +391,50 @@ namespace Google.VersionHandlerImpl.Tests {
                     "Foo/Bar", "Assets"),
                 Is.EqualTo("Foo/Bar"));
         }
+
+        /// <summary>
+        /// Test FileUtils.IsValidGuid() when it returns true
+        /// </summary>
+        [Test]
+        public void IsValidGuid_TrueCases() {
+            Assert.That(
+                FileUtils.IsValidGuid("4b7c4a82-79ca-4eb5-a154-5d78a3b3d3d7"),
+                Is.EqualTo(true));
+
+            Assert.That(
+                FileUtils.IsValidGuid("017885d9f22374a53844077ede0ccda6"),
+                Is.EqualTo(true));
+        }
+
+        /// <summary>
+        /// Test FileUtils.IsValidGuid() when it returns false
+        /// </summary>
+        [Test]
+        public void IsValidGuid_FalseCases() {
+            Assert.That(
+                FileUtils.IsValidGuid(""),
+                Is.EqualTo(false));
+            Assert.That(
+                FileUtils.IsValidGuid(null),
+                Is.EqualTo(false));
+            Assert.That(
+                FileUtils.IsValidGuid("00000000-0000-0000-0000-000000000000"),
+                Is.EqualTo(false));
+            Assert.That(
+                FileUtils.IsValidGuid("00000000000000000000000000000000"),
+                Is.EqualTo(false));
+            Assert.That(
+                FileUtils.IsValidGuid("g000000000000000000000000000000"),
+                Is.EqualTo(false));
+            Assert.That(
+                FileUtils.IsValidGuid("   "),
+                Is.EqualTo(false));
+            Assert.That(
+                FileUtils.IsValidGuid("12300000 0000 0000 0000 000000000000"),
+                Is.EqualTo(false));
+            Assert.That(
+                FileUtils.IsValidGuid("12300000\n0000\n0000\n0000\n000000000000"),
+                Is.EqualTo(false));
+        }
     }
 }


### PR DESCRIPTION
With certain version of Unity, ex. 2022.2.0b8 or 2023.1.0a11, `AssetDatabase.CreateFolder()` can fail when the folder name is version number like `9.0.0`. In this case, the API does not return empty guid but a guid with zeroes.

This change make sure that the folder can still be created using `Directory.CreateDirectory()`, which may not trigger AssetDatabase refresh in the older version of Unity.