### PR TITLE
Change EditorMeasurement to use secure connection (Fixed #484)

### DIFF
--- a/source/VersionHandlerImpl/src/EditorMeasurement.cs
+++ b/source/VersionHandlerImpl/src/EditorMeasurement.cs
@@ -514,7 +514,7 @@ public class EditorMeasurement {
                     if (String.IsNullOrEmpty(cookie.Key)) continue;
                     // See https://developers.google.com/analytics/devguides/collection/protocol/v1
                     var status = PortableWebRequest.DefaultInstance.Post(
-                        "http://www.google-analytics.com/collect",
+                        "https://www.google-analytics.com/collect",
                         new[] {
                             // Version
                             new KeyValuePair<string, string>("v", "1"),

--- a/source/VersionHandlerImpl/unit_tests/src/EditorMeasurementTest.cs
+++ b/source/VersionHandlerImpl/unit_tests/src/EditorMeasurementTest.cs
@@ -366,7 +366,7 @@ namespace Google.VersionHandlerImpl.Tests {
         private KeyValuePair<string, string> CreateMeasurementEvent(
                 string reportUrl, string reportName, string cookie) {
             return new KeyValuePair<string, string>(
-                String.Format("http://www.google-analytics.com/collect" +
+                String.Format("https://www.google-analytics.com/collect" +
                               "?v=1" +
                               "&tid={0}" +
                               "&cid={1}" +


### PR DESCRIPTION
#484 

`EditorMeasurement` used to use `http://` instead of `https://` to report editor usage. This is causing later version of Unity  to log warnings and errors. Even though this is harmless, the logs still looks concerning.

This change basically change `http` to `https`.

# Testing
- Local integration test with Unity 2018-2021.
- Manual test using Firebase Analytics with Unity 2022-2023 because EDM4U current cannot be built by the build tools from Unity 2022-2023.