### PR TITLE
Add log when Unity failed to create folder

### DIFF
--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -2468,7 +2468,7 @@ namespace GooglePlayServices {
             }
 
             var targetDir = Path.GetDirectoryName(targetLocation);
-            if (!FileUtils.CreateFolder(targetDir)) {
+            if (!FileUtils.CreateFolder(targetDir, logger)) {
                 return String.Format("Failed to create folders at {0}", targetDir);
             }
 

--- a/source/VersionHandlerImpl/src/FileUtils.cs
+++ b/source/VersionHandlerImpl/src/FileUtils.cs
@@ -639,7 +639,7 @@ namespace Google {
         /// </summary>
         /// <param name="path">Path to the file/directory that needs checking.</param>
         /// <returns>True if all folders are created successfully.</returns>
-        public static bool CreateFolder(string path) {
+        public static bool CreateFolder(string path, Google.Logger logger = null) {
             if (AssetDatabase.IsValidFolder(path)) {
                 return true;
             }
@@ -654,6 +654,20 @@ namespace Google {
             // returnig empty guid, it can return guids with all zeroes.
             if (IsValidGuid(AssetDatabase.CreateFolder(parentFolder, di.Name))) {
                 return true;
+            }
+
+            if (logger != null) {
+                logger.Log(
+                    String.Format(
+                        "Please ignore Unity error message like '{0}'.\n" +
+                        "Unable to use Unity API `AssetDatabase.CreateFolder()` to " +
+                        "create folder: '{1}'. Switch to use `Directory.CreateDirectory()` " +
+                        "instead. \n\n" +
+                        "See {2} for more information.",
+                        "*** is not a valid directory name.",
+                        path,
+                        "https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-7046"),
+                    LogLevel.Info);
             }
 
             return Directory.CreateDirectory(path) != null;

--- a/source/VersionHandlerImpl/src/FileUtils.cs
+++ b/source/VersionHandlerImpl/src/FileUtils.cs
@@ -659,7 +659,7 @@ namespace Google {
             if (logger != null) {
                 logger.Log(
                     String.Format(
-                        "Please ignore Unity error message like '{0}'.\n" +
+                        "Please ignore Unity error messages similar to '{0}'.\n" +
                         "Unable to use Unity API `AssetDatabase.CreateFolder()` to " +
                         "create folder: '{1}'. Switch to use `Directory.CreateDirectory()` " +
                         "instead. \n\n" +


### PR DESCRIPTION
Follow up for #543. When Unity failed to create folder using Unity API `AssetDatabase.CreateFolder()`, even with the workaround in #543, Unity would still generate two error message and there is no way to turn it off.

This change add an additional log after Unity API fails to inform the user to ignore this error.