### PR TITLE
Avoid calling UpdateVersionedAssetsOnUpdate with each Play in Editor.

### DIFF
--- a/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
+++ b/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
@@ -2299,11 +2299,14 @@ public class VersionHandlerImpl : AssetPostprocessor {
     /// and remove files from older manifest files.
     /// </summary>
     static VersionHandlerImpl() {
-        Log("Loaded VersionHandlerImpl", verbose: true);
-        RunOnMainThread.Run(() => {
-                LoadLogPreferences();
-                UpdateVersionedAssetsOnUpdate();
-            }, runNow: false);
+		if (!EditorApplication.isPlayingOrWillChangePlaymode)
+		{
+			Log("Loaded VersionHandlerImpl", verbose: true);
+			RunOnMainThread.Run(() => {
+					LoadLogPreferences();
+					UpdateVersionedAssetsOnUpdate();
+				}, runNow: false);
+		}
     }
 
     static void UpdateVersionedAssetsOnUpdate() {


### PR DESCRIPTION
Avoid unecessary computation of manifest each time the play mode is started in editor.
This computation takes multiple seconds each time we press play on many projects.
This computation is already made with each asset refresh.

Please note that this was already made on the fidebase-unity-sdk equivalent few years ago: `GenerateXmlFromGoogleServicesJson`
https://github.com/firebase/firebase-unity-sdk/blob/778a4841ac67616b2bd88a6e6f740a816d75b13b/editor/app/src/GenerateXmlFromGoogleServicesJson.cs#L96