### PR TITLE
Add two Android Resolver settings related to custom local Maven repo path

### DIFF
--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -2120,6 +2120,12 @@ namespace GooglePlayServices {
             var lines = new List<string>();
             if (dependencies.Count > 0) {
                 var exportEnabled = GradleProjectExportEnabled;
+                var useFullPath = (
+                        exportEnabled &&
+                        SettingsDialogObj.UseFullCustomMavenRepoPathWhenExport ) || (
+                        !exportEnabled &&
+                        SettingsDialogObj.UseFullCustomMavenRepoPathWhenNotExport);
+
                 var projectPath = FileUtils.PosixPathSeparators(Path.GetFullPath("."));
                 var projectFileUri = GradleResolver.RepoPathToUri(projectPath);
                 lines.Add("([rootProject] + (rootProject.subprojects as List)).each { project ->");
@@ -2127,9 +2133,11 @@ namespace GooglePlayServices {
                 // projectPath will point to the Unity project root directory as Unity will
                 // generate the root Gradle project in "Temp/gradleOut" when *not* exporting a
                 // gradle project.
-                lines.Add(String.Format(
-                          "        def unityProjectPath = $/{0}**DIR_UNITYPROJECT**/$" +
-                          ".replace(\"\\\\\", \"/\")", GradleWrapper.FILE_SCHEME));
+                if (!useFullPath) {
+                    lines.Add(String.Format(
+                            "        def unityProjectPath = $/{0}**DIR_UNITYPROJECT**/$" +
+                            ".replace(\"\\\\\", \"/\")", GradleWrapper.FILE_SCHEME));
+                }
                 lines.Add("        maven {");
                 lines.Add("            url \"https://maven.google.com\"");
                 lines.Add("        }");
@@ -2154,9 +2162,7 @@ namespace GooglePlayServices {
                             repoPath = relativePath;
                         }
 
-                        // If "Export Gradle Project" setting is enabled, gradle project expects
-                        // absolute path.
-                        if (exportEnabled) {
+                        if (useFullPath) {
                             // build.gradle expects file:/// URI so file separator will be "/" in anycase
                             // and we must NOT use Path.Combine here because it will use "\" for win platforms
                             repoUri = String.Format("\"{0}/{1}\"", projectFileUri, repoPath);
@@ -2541,6 +2547,8 @@ namespace GooglePlayServices {
                 {"explodeAars", SettingsDialogObj.ExplodeAars.ToString()},
                 {"patchAndroidManifest", SettingsDialogObj.PatchAndroidManifest.ToString()},
                 {"patchMainTemplateGradle", SettingsDialogObj.PatchMainTemplateGradle.ToString()},
+                {"useFullCustomMavenRepoPathWhenExport", SettingsDialogObj.UseFullCustomMavenRepoPathWhenExport.ToString()},
+                {"useFullCustomMavenRepoPathWhenNotExport", SettingsDialogObj.UseFullCustomMavenRepoPathWhenNotExport.ToString()},
                 {"localMavenRepoDir", SettingsDialogObj.LocalMavenRepoDir.ToString()},
                 {"useJetifier", SettingsDialogObj.UseJetifier.ToString()},
                 {"bundleId", GetAndroidApplicationId()},
@@ -2558,6 +2566,8 @@ namespace GooglePlayServices {
             "explodeAars",
             "patchAndroidManifest",
             "patchMainTemplateGradle",
+            "useFullCustomMavenRepoPathWhenExport",
+            "useFullCustomMavenRepoPathWhenNotExport",
             "localMavenRepoDir",
             "useJetifier",
             "gradleBuildEnabled",

--- a/source/AndroidResolver/src/SettingsDialog.cs
+++ b/source/AndroidResolver/src/SettingsDialog.cs
@@ -39,6 +39,8 @@ namespace GooglePlayServices {
             internal bool patchAndroidManifest;
             internal bool patchMainTemplateGradle;
             internal bool patchPropertiesTemplateGradle;
+            internal bool useFullCustomMavenRepoPathWhenExport;
+            internal bool useFullCustomMavenRepoPathWhenNotExport;
             internal string localMavenRepoDir;
             internal bool useJetifier;
             internal bool verboseLogging;
@@ -60,6 +62,8 @@ namespace GooglePlayServices {
                 patchAndroidManifest = SettingsDialog.PatchAndroidManifest;
                 patchMainTemplateGradle = SettingsDialog.PatchMainTemplateGradle;
                 patchPropertiesTemplateGradle = SettingsDialog.PatchPropertiesTemplateGradle;
+                useFullCustomMavenRepoPathWhenExport = SettingsDialog.UseFullCustomMavenRepoPathWhenExport;
+                useFullCustomMavenRepoPathWhenNotExport = SettingsDialog.UseFullCustomMavenRepoPathWhenNotExport;
                 localMavenRepoDir = SettingsDialog.LocalMavenRepoDir;
                 useJetifier = SettingsDialog.UseJetifier;
                 verboseLogging = SettingsDialog.VerboseLogging;
@@ -82,6 +86,8 @@ namespace GooglePlayServices {
                 SettingsDialog.PatchAndroidManifest = patchAndroidManifest;
                 SettingsDialog.PatchMainTemplateGradle = patchMainTemplateGradle;
                 SettingsDialog.PatchPropertiesTemplateGradle = patchPropertiesTemplateGradle;
+                SettingsDialog.UseFullCustomMavenRepoPathWhenExport = useFullCustomMavenRepoPathWhenExport;
+                SettingsDialog.UseFullCustomMavenRepoPathWhenNotExport = useFullCustomMavenRepoPathWhenNotExport;
                 SettingsDialog.LocalMavenRepoDir = localMavenRepoDir;
                 SettingsDialog.UseJetifier = useJetifier;
                 SettingsDialog.VerboseLogging = verboseLogging;
@@ -101,6 +107,8 @@ namespace GooglePlayServices {
         private const string PatchAndroidManifestKey = Namespace + "PatchAndroidManifest";
         private const string PatchMainTemplateGradleKey = Namespace + "PatchMainTemplateGradle";
         private const string PatchPropertiesTemplateGradleKey = Namespace + "PatchPropertiesTemplateGradle";
+        private const string UseFullCustomMavenRepoPathWhenExportKey = Namespace + "UseFullCustomMavenRepoPathWhenExport";
+        private const string UseFullCustomMavenRepoPathWhenNotExportKey = Namespace + "UseFullCustomMavenRepoPathWhenNotExport";
         private const string LocalMavenRepoDirKey = Namespace + "LocalMavenRepoDir";
         private const string UseJetifierKey = Namespace + "UseJetifier";
         private const string VerboseLoggingKey = Namespace + "VerboseLogging";
@@ -120,6 +128,8 @@ namespace GooglePlayServices {
             PatchAndroidManifestKey,
             PatchMainTemplateGradleKey,
             PatchPropertiesTemplateGradleKey,
+            UseFullCustomMavenRepoPathWhenExportKey,
+            UseFullCustomMavenRepoPathWhenNotExportKey,
             LocalMavenRepoDirKey,
             UseJetifierKey,
             VerboseLoggingKey,
@@ -243,6 +253,16 @@ namespace GooglePlayServices {
         internal static bool PatchPropertiesTemplateGradle {
             set { projectSettings.SetBool(PatchPropertiesTemplateGradleKey, value); }
             get { return projectSettings.GetBool(PatchPropertiesTemplateGradleKey, true); }
+        }
+
+        internal static bool UseFullCustomMavenRepoPathWhenExport {
+            set { projectSettings.SetBool(UseFullCustomMavenRepoPathWhenExportKey, value); }
+            get { return projectSettings.GetBool(UseFullCustomMavenRepoPathWhenExportKey, true); }
+        }
+
+        internal static bool UseFullCustomMavenRepoPathWhenNotExport {
+            set { projectSettings.SetBool(UseFullCustomMavenRepoPathWhenNotExportKey, value); }
+            get { return projectSettings.GetBool(UseFullCustomMavenRepoPathWhenNotExportKey, false); }
         }
 
         internal static string LocalMavenRepoDir {
@@ -479,6 +499,44 @@ namespace GooglePlayServices {
             }
 
             if (settings.patchMainTemplateGradle) {
+                GUILayout.Label("Use Full Custom Local Maven Repo Path", EditorStyles.boldLabel);
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("  When building Android app through Unity", EditorStyles.boldLabel);
+                settings.useFullCustomMavenRepoPathWhenNotExport =
+                    EditorGUILayout.Toggle(settings.useFullCustomMavenRepoPathWhenNotExport);
+                GUILayout.EndHorizontal();
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("  When exporting Android project", EditorStyles.boldLabel);
+                settings.useFullCustomMavenRepoPathWhenExport =
+                    EditorGUILayout.Toggle(settings.useFullCustomMavenRepoPathWhenExport);
+                GUILayout.EndHorizontal();
+
+                GUILayout.Label(
+                    "EDM4U can inject custom local Maven repo to Gradle template files " +
+                    "differnetly depending on whether 'Export Project' in Build Settings is " +
+                    "enabled or not.\n" +
+                    "If checked, custom local Maven repo path will look like the following. " +
+                    "This is best if the Unity project is always under the same path, or when " +
+                    "Unity editor has bugs which fail to resolve template variables like " +
+                    "'**DIR_UNITYPROJECT**'");
+                GUILayout.Box(
+                    "  maven {\n" +
+                    "    url \"file:////path/to/myUnityProject/path/to/m2repository\"\n" +
+                    "  }", EditorStyles.wordWrappedMiniLabel);
+                GUILayout.Label(
+                    "If unchecked, custom local Maven repo path will look like the following. " +
+                    "This is best if the Unity projects locates in different folders on " +
+                    "different workstations. 'unityProjectPath' will be resolved at build time " +
+                    "using template variables like '**DIR_UNITYPROJECT**'");
+                GUILayout.Box(
+                    "  def unityProjectPath = $/file:///**DIR_UNITYPROJECT**/$.replace(\"\\\", \"/\")\n" +
+                    "  maven {\n" +
+                    "    url (unityProjectPath + \"/path/to/m2repository\")\n" +
+                    "  }", EditorStyles.wordWrappedMiniLabel);
+                GUILayout.Label(
+                    "Note that EDM4U always uses full path if the custom local Maven repo is NOT " +
+                    "under Unity project folder.");
+
                 GUILayout.BeginHorizontal();
                 string previousDir = settings.localMavenRepoDir;
                 GUILayout.Label("Local Maven Repo Directory", EditorStyles.boldLabel);
@@ -587,6 +645,12 @@ namespace GooglePlayServices {
                         new KeyValuePair<string, string>(
                             "patchAndroidManifest",
                             SettingsDialog.PatchAndroidManifest.ToString()),
+                        new KeyValuePair<string, string>(
+                            "UseFullCustomMavenRepoPathWhenNotExport",
+                            SettingsDialog.UseFullCustomMavenRepoPathWhenNotExport.ToString()),
+                        new KeyValuePair<string, string>(
+                            "UseFullCustomMavenRepoPathWhenExport",
+                            SettingsDialog.UseFullCustomMavenRepoPathWhenExport.ToString()),
                         new KeyValuePair<string, string>(
                             "localMavenRepoDir",
                             SettingsDialog.LocalMavenRepoDir.ToString()),

--- a/source/AndroidResolver/src/SettingsDialog.cs
+++ b/source/AndroidResolver/src/SettingsDialog.cs
@@ -337,6 +337,8 @@ namespace GooglePlayServices {
         /// Called when the GUI should be rendered.
         /// </summary>
         public void OnGUI() {
+            GUI.skin.label.wordWrap = true;
+
             GUILayout.BeginVertical();
             GUILayout.Label(String.Format("Android Resolver (version {0}.{1}.{2})",
                                           AndroidResolverVersionNumber.Value.Major,
@@ -543,6 +545,10 @@ namespace GooglePlayServices {
             settings.useProjectSettings = EditorGUILayout.Toggle(settings.useProjectSettings);
             GUILayout.EndHorizontal();
 
+            GUILayout.EndVertical();
+            EditorGUILayout.EndScrollView();
+
+            GUILayout.BeginVertical();
             GUILayout.Space(10);
 
             if (GUILayout.Button("Reset to Defaults")) {
@@ -604,9 +610,8 @@ namespace GooglePlayServices {
             }
             if (closeWindow) Close();
             GUILayout.EndHorizontal();
-
             GUILayout.EndVertical();
-            EditorGUILayout.EndScrollView();
+
             GUILayout.EndVertical();
         }
     }


### PR DESCRIPTION
Adding two settings in Android Resolver settings to determine whether EDM4U inject custom local Maven repo path as a relative path or full path.

Before these settings, EDM4U has internal logic to always use full path when exporting project and relative path when not. Provide the new options so that the developers can choose to make it consistent or use full path to avoid certain Unity bugs.

Added a new task (Bug# 274671088) to add integration test for this. Currently manually verified with Unity 2022.2 and all integration tests are passed (primarily due to lack of test for full path scenario)