### PR TITLE
Enable Jetifier by default

### DIFF
--- a/source/AndroidResolver/src/SettingsDialog.cs
+++ b/source/AndroidResolver/src/SettingsDialog.cs
@@ -285,7 +285,7 @@ namespace GooglePlayServices {
 
         internal static bool UseJetifier {
             set { projectSettings.SetBool(UseJetifierKey, value); }
-            get { return projectSettings.GetBool(UseJetifierKey, false); }
+            get { return projectSettings.GetBool(UseJetifierKey, true); }
         }
 
         internal static bool VerboseLogging {


### PR DESCRIPTION
AndroidX and Jetifier was introduce in 2019. There are higher and higher chance to have mix use of legacy support library and AndroidX support libraries.

Currently EDM4U can only detect if Jetifier is needed when `Custom Main Gradle Template` is not enabled, that is, when EDM4U downloads Android libraries to `Assets/Plugins/Android` folders. It is harder to detect the need of Jetfifier if the dependency is specified in Gradle templates.

This change will set `Use Jetifier` settings to `true` by default. 