### PR TITLE
Revert "Do not explode AARs even if gradle project is not enabled"

### DIFF
--- a/source/AndroidResolver/src/GradleResolver.cs
+++ b/source/AndroidResolver/src/GradleResolver.cs
@@ -1161,7 +1161,7 @@ namespace GooglePlayServices
             // To work around this when Gradle builds are enabled, explosion is enabled for all
             // AARs that require variable expansion unless this behavior is explicitly disabled
             // in the settings dialog.
-            if (PlayServicesResolver.GradleProjectExportEnabled || !SettingsDialog.ExplodeAars) {
+            if (PlayServicesResolver.GradleProjectExportEnabled && !SettingsDialog.ExplodeAars) {
                 return false;
             }
             // If this version of Unity doesn't support AAR files, always explode.


### PR DESCRIPTION
Reverts googlesamples/unity-jar-resolver#593

This is failing the following tests
```
Test ResolveForGradleBuildSystemAndExport: FAILED
Test ResolveAddedDependencies: FAILED
Test ResolveRemovedDependencies: FAILED
Test DeleteResolvedLibraries: FAILED
```

Also, this change is a bit problematic since it means Android Resolver will NEVER explore AAR when export project is enabled.