### PR TITLE
`Explode Aar` option applies to all cases

### DIFF
--- a/source/AndroidResolver/src/GradleResolver.cs
+++ b/source/AndroidResolver/src/GradleResolver.cs
@@ -1161,7 +1161,7 @@ namespace GooglePlayServices
             // To work around this when Gradle builds are enabled, explosion is enabled for all
             // AARs that require variable expansion unless this behavior is explicitly disabled
             // in the settings dialog.
-            if (PlayServicesResolver.GradleProjectExportEnabled && !SettingsDialog.ExplodeAars) {
+            if (!SettingsDialog.ExplodeAars) {
                 return false;
             }
             // If this version of Unity doesn't support AAR files, always explode.

--- a/source/AndroidResolver/src/SettingsDialog.cs
+++ b/source/AndroidResolver/src/SettingsDialog.cs
@@ -442,8 +442,8 @@ namespace GooglePlayServices {
                                 "AndroidManifest.xml or a single target ABI is selected " +
                                 "without a compatible build system.");
             } else {
-                GUILayout.Label("AAR explosion will be disabled in exported Gradle builds " +
-                                "(Unity 5.5 and above). You will need to set " +
+                GUILayout.Label("AAR explosion will be disabled." +
+                                "You may need to set " +
                                 "android.defaultConfig.applicationId to your bundle ID in your " +
                                 "build.gradle to generate a functional APK.");
             }


### PR DESCRIPTION
Before this change, `Explode Aar` option in Android Resolver settings only applies when `Export Project` build setting is enabled, while Android Resolver always explode Aar libraries when the build setting is disabled.

This changes `Explode Aar` option to be applied no matter `Export Project` build setting is enabled or not. It is still recommended to enable this option for older version of Unity (5 to 2018) since certain version of Unity may generate broken Gradle project.

Fixes #584
Fixes #287