### PR TITLE
Fix failing tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1950,23 +1950,6 @@ createUnityIntegrationTest(
    new File("Google.PackageManagerClientIntegrationTests.dll.mdb")],
   null, [])
 
-createUnityIntegrationTest(
-  "testPackageMigratorIntegrationTests",
-  ("Imports the plugin into a Unity project and uses the Package Migrator " +
-   "list packages that can be migrated and self migrate EDM to UPM. "),
-  [compilePackageManagerResolver],
-  "PackageMigratorIntegrationTests",
-  fileTree(new File(new File(new File(project.ext.pluginSourceDir,
-                             "PackageManagerResolver"), "test"),
-                    "PackageMigratorIntegrationTests")),
-  [new File("Google.PackageMigratorIntegrationTests.dll"),
-   new File("Google.PackageMigratorIntegrationTests.dll.mdb")],
-  new File(
-    project.ext.scriptDirectory,
-    "source/PackageManagerResolver/test/" +
-    "PackageMigratorIntegrationTestsUnityProject"),
-  [])
-
 task cleanTests(type: Delete) {
   description "Clean test directories."
   delete project.ext.testDir

--- a/build.gradle
+++ b/build.gradle
@@ -291,7 +291,7 @@ project.ext {
   // Pip binary after it has been bootstrapped.
   pipExe = new File(pythonBinDir, "pip3")
   // Python packages required by export_unity_package.py
-  exportUnityPackageRequirements = ["absl-py", "PyYAML"]
+  exportUnityPackageRequirements = ["absl-py", "PyYAML", "packaging"]
   // Python packages required by gen_guids.py
   genGuidRequirements = ["absl-py"]
 }

--- a/source/AndroidResolver/test/AndroidResolverIntegrationTestsUnityProject/ProjectSettings/GvhProjectSettings.xml
+++ b/source/AndroidResolver/test/AndroidResolverIntegrationTestsUnityProject/ProjectSettings/GvhProjectSettings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<projectSettings>
+  <projectSetting name="GooglePlayServices.AutoResolverEnabled" value="False" />
+  <projectSetting name="GooglePlayServices.PromptBeforeAutoResolution" value="False" />
+</projectSettings>

--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -293,7 +293,7 @@ import zipfile
 from absl import app
 from absl import flags
 from absl import logging
-import distutils.version
+import packaging.version
 import yaml
 
 FLAGS = flags.FLAGS
@@ -983,11 +983,11 @@ class GuidDatabase(object):
 
       if plugin_version:
         # Aggregate guids for older versions of files.
-        current_version = distutils.version.LooseVersion(plugin_version)
-        for version in sorted(guids_json, key=distutils.version.LooseVersion,
+        current_version = packaging.version.Version(plugin_version)
+        for version in sorted(guids_json, key=packaging.version.Version,
                               reverse=True):
           # Skip all versions after and including the current version.
-          if distutils.version.LooseVersion(version) >= current_version:
+          if packaging.version.Version(version) >= current_version:
             continue
           # Add all guids for files to the current version.
           guids_by_filename = guids_json[version]


### PR DESCRIPTION
Fix a couple of test fails for various reasons

- AndroidResolverIntegrationTest fails because auto-resolution is enabled from the beginning. This is messing around with the next test after the previous one is finished, specifically in interactive mode (not batch mode)
- Fix the use of deprecated Python package `distutils`
- Remove invalid PackageMigratorIntegration test because there is no registry to test against. 