### PR TITLE
Add /opt/homebrew/bin to POD_SEARCH_PATHS

### DIFF
--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -445,6 +445,7 @@ public class IOSResolver : AssetPostprocessor {
     private static string[] POD_SEARCH_PATHS = new string[] {
         "/usr/local/bin",
         "/usr/bin",
+        "/opt/homebrew/bin",
     };
     // Ruby Gem executable filename.
     private static string GEM_EXECUTABLE = "gem";


### PR DESCRIPTION
On M1 macs, homebrew installs to /opt/homebrew/bin instead of /usr/local/bin. 
See https://github.com/Homebrew/brew/issues/9177 for an official source on this.

This change will increase the consistency of the pod command being found on such systems. This change was requested in #627