### PR TITLE
GHA to build EDM4U on x86 Mac

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,8 @@ on:
         description: 'Unity version'
         default: '2019'
         type: string
-       required: true
+        required: true
+
 env:
   # Use SHA256 for hashing files.
   hashCommand: "sha256sum"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,26 @@
-name: EDM4U build
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-on: 
+name: Build
+
+on:
+  schedule:
+    - cron: "0 10 * * *"  # 10am UTC = 2am PST
+
+  pull_request:
+    types: [ labeled, closed ]
+
   workflow_dispatch:
     inputs:
       unity_version:
@@ -10,14 +30,44 @@ on:
         type: string
 
 env:
-  pythonVersion: '3.7'
-  
-  
+  # Use SHA256 for hashing files.
+  hashCommand: "sha256sum"
+
 jobs:
-  build_desktop:
-    name: build-macOS-unity${{ inputs.unity_version}}
-    runs-on: macos-latest
+  build_macos:
+    name: build-macos-unity${{ inputs.unity_version}}
+    uses: ./.github/workflows/build_macos.yaml
+    with:
+      unity_version: ${{ inputs.unity_version}}
+
+  finalizing:
+    # Only compute SHA hash for macOS build
+    name: finalizing-macOS-unity${{ inputs.unity_version}}
+    needs: [build_macos]
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: python -v
-      - run: sysctl -n machdep.cpu.brand_string
+      - name: Fetch All builds
+        uses: actions/download-artifact@v3
+        with:
+          path: built_artifact
+
+      - name: Compute Plugin Hash
+        shell: bash
+        run: |
+          # Compute hash for .tgz package
+          pushd built_artifact/TarballPackage_macOS
+          tgz_files_list=$(find -type f -name '*.tgz')
+          for tgz_file in "${tgz_files_list[@]}"; do
+            echo tgz_file
+            ${{ env.hashCommand }} --tag ${tgz_file} >> edm4u_hash.txt
+          done
+          echo "::warning update sha txt \n ::$(cat edm4u_hash.txt)"
+          popd
+
+          # Compute hash for .unitypackage package
+          pushd built_artifact/AssetPackage_macOS
+          ${{ env.hashCommand }} --tag external-dependency-manager.unitypackage >> edm4u_hash.txt
+          echo "::warning update sha txt \n ::$(cat edm4u_hash.txt)"
+          popd
+
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,10 @@ on:
         description: 'Unity version'
         default: '2019'
         required: true
-        type: string
+        type: choice
+        options:
+          - 2019
+          - 2020
 
 env:
   # Use SHA256 for hashing files.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Workflow to build EDM4U packages and compute their hash
-name: Build All
+name: Build
 
 on:
   schedule:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,13 +61,14 @@ jobs:
             echo tgz_file
             ${{ env.hashCommand }} --tag ${tgz_file} >> edm4u_hash.txt
           done
-          echo "::warning update sha txt \n ::$(cat edm4u_hash.txt)"
+          # echo "::warning update sha txt \n ::$(cat edm4u_hash.txt)"
           popd
 
           # Compute hash for .unitypackage package
           pushd built_artifact/AssetPackage_macOS
           ${{ env.hashCommand }} --tag external-dependency-manager.unitypackage >> edm4u_hash.txt
           echo "::warning update sha txt \n ::$(cat edm4u_hash.txt)"
+          cat edm4u_hash.txt
           popd
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build
+# Workflow to build EDM4U packages and compute their hash
+name: Build All
 
 on:
   schedule:
@@ -61,14 +62,13 @@ jobs:
             echo tgz_file
             ${{ env.hashCommand }} --tag ${tgz_file} >> edm4u_hash.txt
           done
-          # echo "::warning update sha txt \n ::$(cat edm4u_hash.txt)"
+          echo "::warning update sha txt \n ::$(cat edm4u_hash.txt)"
           popd
 
           # Compute hash for .unitypackage package
           pushd built_artifact/AssetPackage_macOS
           ${{ env.hashCommand }} --tag external-dependency-manager.unitypackage >> edm4u_hash.txt
           echo "::warning update sha txt \n ::$(cat edm4u_hash.txt)"
-          cat edm4u_hash.txt
           popd
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,9 +29,8 @@ on:
         required: true
         type: choice
         options:
-          - 2019
-          - 2020
-
+          - '2019'
+          - '2020'
 env:
   # Use SHA256 for hashing files.
   hashCommand: "sha256sum"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,12 +25,12 @@ on:
     inputs:
       unity_version:
         description: 'Unity version'
-        default: '2019'
-        required: true
+        default: 2019
         type: choice
         options:
-          - '2019'
-          - '2020'
+          - 2019
+          - 2020
+        required: true
 env:
   # Use SHA256 for hashing files.
   hashCommand: "sha256sum"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,13 +62,13 @@ jobs:
             echo tgz_file
             ${{ env.hashCommand }} --tag ${tgz_file} >> edm4u_hash.txt
           done
-          echo "::warning update sha txt \n ::$(cat edm4u_hash.txt)"
+          echo "::warning ::$(cat edm4u_hash.txt)"
           popd
 
           # Compute hash for .unitypackage package
           pushd built_artifact/AssetPackage_macOS
           ${{ env.hashCommand }} --tag external-dependency-manager.unitypackage >> edm4u_hash.txt
-          echo "::warning update sha txt \n ::$(cat edm4u_hash.txt)"
+          echo "::warning ::$(cat edm4u_hash.txt)"
           popd
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,12 +25,9 @@ on:
     inputs:
       unity_version:
         description: 'Unity version'
-        default: 2019
-        type: choice
-        options:
-          - 2019
-          - 2020
-        required: true
+        default: '2019'
+        type: string
+       required: true
 env:
   # Use SHA256 for hashing files.
   hashCommand: "sha256sum"

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Workflow to handle building the EDM4U on macOS
+# Workflow to build EDM4U packages on macOS
 name: Build macOS (SubWorkflow)
 
 on:

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -22,7 +22,10 @@ on:
         description: 'Unity version'
         default: '2019'
         required: true
-        type: string
+        type: choice
+        options:
+          - 2019
+          - 2020
 
 env:
   pythonVersion: '3.7'

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -24,8 +24,8 @@ on:
         required: true
         type: choice
         options:
-          - 2019
-          - 2020
+          - '2019'
+          - '2020'
 
 env:
   pythonVersion: '3.7'
@@ -66,7 +66,7 @@ jobs:
 
       - name: Return Unity license
         if: always()
-        uses: ./external/firebase-unity-sdk/gha/unity
+        uses: firebase/firebase-unity-sdk/gha/unity@main
         with:
           version: ${{ inputs.unity_version }}
           release_license: "true"

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -1,0 +1,101 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Workflow to handle building the EDM4U on macOS
+name: Build macOS (SubWorkflow)
+
+on:
+  workflow_call:
+    inputs:
+      unity_version:
+        description: 'Unity version'
+        default: '2019'
+        required: true
+        type: string
+
+env:
+  pythonVersion: '3.7'
+  artifactRetentionDays: 2
+  assetPackageArtifactName: "AssetPackage_macOS"
+  tarballPackageArtifactName: "TarballPackage_macOS"
+
+jobs:
+  build_desktop:
+    name: build-macOS-unity${{ inputs.unity_version}}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: build_setup
+        uses: ./gha/build_setup
+        timeout-minutes: 30
+        with:
+          unity_version: ${{ inputs.unity_version }}
+          platform: macOS
+          python_version: ${{ env.pythonVersion }}
+          unity_username: ${{ secrets.UNITY_USERNAME }}
+          unity_password: ${{ secrets.UNITY_PASSWORD }}
+          unity_serial_ids: ${{ secrets.SERIAL_ID }}
+
+      - name: Set Unity Env for EDM4U build script
+        shell: bash
+        run: echo "UNITY_EXE=${{ env.UNITY_ROOT_DIR }}/Unity.app/Contents/MacOS/Unity" >> $GITHUB_ENV
+
+      # Build .unitypackage
+      - run: ./gradlew buildPlugin --info
+
+      # Build .tgz
+      - run: ./gradlew buildUpmPlugin --info
+
+      - name: Return Unity license
+        if: always()
+        uses: ./external/firebase-unity-sdk/gha/unity
+        with:
+          version: ${{ inputs.unity_version }}
+          release_license: "true"
+
+      - name: Check build files
+        shell: bash
+        run: |
+          if [ -f build/external-dependency-manager.unitypackage ]; then
+            echo "external-dependency-manager.unitypackage zip created."
+          else
+            echo "Fail to create external-dependency-manager.unitypackage."
+            exit 1
+          fi
+          if ls build/com.google.external-dependency-manager*.tgz 1> /dev/null 2>&1; then
+            echo "com.google.external-dependency-manager.tgz created."
+          else
+            echo "Fail to create com.google.external-dependency-manager.tgz ."
+            exit 1
+          fi
+
+      - name: Upload build results artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        with:
+          name: ${{ env.assetPackageArtifactName }}
+          path: build/external-dependency-manager.unitypackage
+          retention-days: ${{ env.artifactRetentionDays }}
+
+      - name: Upload build results artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        with:
+          name: ${{ env.tarballPackageArtifactName }}
+          path: build/com.google.external-dependency-manager-*.tgz
+          retention-days: ${{ env.artifactRetentionDays }}

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -20,12 +20,12 @@ on:
     inputs:
       unity_version:
         description: 'Unity version'
-        default: '2019'
-        required: true
+        default: 2019
         type: choice
         options:
-          - '2019'
-          - '2020'
+          - 2019
+          - 2020
+        required: true
 
 env:
   pythonVersion: '3.7'

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -20,11 +20,8 @@ on:
     inputs:
       unity_version:
         description: 'Unity version'
-        default: 2019
-        type: choice
-        options:
-          - 2019
-          - 2020
+        default: '2019'
+        type: string
         required: true
 
 env:

--- a/gha/build_setup/action.yml
+++ b/gha/build_setup/action.yml
@@ -56,8 +56,19 @@ runs:
       run: |
         pip install -r ./external/firebase-unity-sdk/scripts/gha/requirements.txt
 
+    # - name: unity_setup
+    #   uses: ./external/firebase-unity-sdk/gha/unity
+    #   with:
+    #     version: ${{ inputs.unity_version }}
+    #     # iOS build support is always required to build EDM4U
+    #     platforms: "${{ inputs.platform }},iOS"
+    #     username: ${{ inputs.unity_username }}
+    #     password: ${{ inputs.unity_password }}
+    #     serial_ids: ${{ inputs.unity_serial_ids }}
+
     - name: unity_setup
-      uses: ./external/firebase-unity-sdk/gha/unity
+      uses: firebase/firebase-unity-sdk/gha/unity@main
+      secrets: inherit # pass all secrets
       with:
         version: ${{ inputs.unity_version }}
         # iOS build support is always required to build EDM4U
@@ -65,3 +76,4 @@ runs:
         username: ${{ inputs.unity_username }}
         password: ${{ inputs.unity_password }}
         serial_ids: ${{ inputs.unity_serial_ids }}
+

--- a/gha/build_setup/action.yml
+++ b/gha/build_setup/action.yml
@@ -42,7 +42,6 @@ runs:
         repository: firebase/firebase-unity-sdk
         path: external/firebase-unity-sdk
         sparse-checkout: |
-          gha
           scripts/gha/requirements.txt
         sparse-checkout-cone-mode: false
 
@@ -56,17 +55,7 @@ runs:
       run: |
         pip install -r ./external/firebase-unity-sdk/scripts/gha/requirements.txt
 
-    # - name: unity_setup
-    #   uses: ./external/firebase-unity-sdk/gha/unity
-    #   with:
-    #     version: ${{ inputs.unity_version }}
-    #     # iOS build support is always required to build EDM4U
-    #     platforms: "${{ inputs.platform }},iOS"
-    #     username: ${{ inputs.unity_username }}
-    #     password: ${{ inputs.unity_password }}
-    #     serial_ids: ${{ inputs.unity_serial_ids }}
-
-    - name: unity_setup
+    - name: Install Unity and get a license
       uses: firebase/firebase-unity-sdk/gha/unity@main
       with:
         version: ${{ inputs.unity_version }}

--- a/gha/build_setup/action.yml
+++ b/gha/build_setup/action.yml
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Reusable workflow to setup for the build environment.
+# Reusable cross-platform workflow to setup for the build environment.
+# * Install Python and required Python packages
+# * Install Unity, platform build support, and register license if
+#   username, password and serial id are provided
 name: 'Build Setup'
 
 inputs:
@@ -30,7 +33,7 @@ inputs:
     required: false
   unity_password:
     required: false
-  unity_serial_ids:
+  unity_serial_id:
     required: false
   python_version:
     required: true
@@ -65,5 +68,5 @@ runs:
         platforms: "${{ inputs.platform }},iOS"
         username: ${{ inputs.unity_username }}
         password: ${{ inputs.unity_password }}
-        serial_ids: ${{ inputs.unity_serial_ids }}
+        serial_ids: ${{ inputs.unity_serial_id }}
 

--- a/gha/build_setup/action.yml
+++ b/gha/build_setup/action.yml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Reusable workflow to setup for the build environment.
 name: 'Build Setup'
+
 inputs:
   unity_version:
     required: true

--- a/gha/build_setup/action.yml
+++ b/gha/build_setup/action.yml
@@ -1,0 +1,67 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Build Setup'
+inputs:
+  unity_version:
+    required: true
+  platform:
+    description: 'Platform to install Unity on (Windows,macOS,Linux)'
+    type: choice
+    options:
+      - Windows
+      - macOS
+      - Linux
+    required: true
+  unity_username:
+    required: false
+  unity_password:
+    required: false
+  unity_serial_ids:
+    required: false
+  python_version:
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    # Download GHA tools and requirements from Firebase Unity SDK repo
+    - uses: actions/checkout@v3
+      with:
+        repository: firebase/firebase-unity-sdk
+        path: external/firebase-unity-sdk
+        sparse-checkout: |
+          gha
+          scripts/gha/requirements.txt
+        sparse-checkout-cone-mode: false
+
+    - name: Setup python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python_version }}
+
+    - name: Install python deps
+      shell: bash
+      run: |
+        pip install -r ./external/firebase-unity-sdk/scripts/gha/requirements.txt
+
+    - name: unity_setup
+      uses: ./external/firebase-unity-sdk/gha/unity
+      with:
+        version: ${{ inputs.unity_version }}
+        # iOS build support is always required to build EDM4U
+        platforms: "${{ inputs.platform }},iOS"
+        username: ${{ inputs.unity_username }}
+        password: ${{ inputs.unity_password }}
+        serial_ids: ${{ inputs.unity_serial_ids }}

--- a/gha/build_setup/action.yml
+++ b/gha/build_setup/action.yml
@@ -68,7 +68,6 @@ runs:
 
     - name: unity_setup
       uses: firebase/firebase-unity-sdk/gha/unity@main
-      secrets: inherit # pass all secrets
       with:
         version: ${{ inputs.unity_version }}
         # iOS build support is always required to build EDM4U


### PR DESCRIPTION
Enabled GHA to build EDM4U on macOS

- Build and upload both `.unitypackage` and `.tgz` as artifacts
- Show SHA256 hash for both packages.
