### PR TITLE
Prevent package from including Mac Metadata file

### DIFF
--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -2543,6 +2543,9 @@ class PackageConfiguration(ConfigurationBlock):
                 os.utime(filename, (FLAGS.timestamp, FLAGS.timestamp))
             # Don't recurse directories.
             tar_args.append("-n")
+            # Avoid creating mac metadata file start with "."
+            if platform.system() == "Darwin":
+              tar_args.append("--no-mac-metadata")
           tar_args.extend(["-T", list_filename])
           # Disable timestamp in the gzip header.
           tar_env = os.environ.copy()

--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -2543,7 +2543,7 @@ class PackageConfiguration(ConfigurationBlock):
                 os.utime(filename, (FLAGS.timestamp, FLAGS.timestamp))
             # Don't recurse directories.
             tar_args.append("-n")
-            # Avoid creating mac metadata file start with "."
+            # Avoid creating mac metadata files with name started with "."
             if platform.system() == "Darwin":
               tar_args.append("--no-mac-metadata")
           tar_args.extend(["-T", list_filename])


### PR DESCRIPTION
If `tar` is run from a macOS, by default, it will create Mac Metadata file for every file and folder which starts with ".". This change makes sure that the archives does not include Mac Metadata file.