### PR TITLE
Fix PackageManagerClientIntegrationTests

### DIFF
--- a/source/PackageManagerResolver/test/PackageManagerClientIntegrationTests/PackageManagerClientIntegrationTests.cs
+++ b/source/PackageManagerResolver/test/PackageManagerClientIntegrationTests/PackageManagerClientIntegrationTests.cs
@@ -165,7 +165,7 @@ public static class PackageManagerClientTests {
                     CheckPackageNamesInPackageInfos(
                         new List<string>() {
                             "com.unity.2d.animation",
-                            "com.unity.entities"
+                            "com.unity.test-framework"
                         },
                         result.Packages, testCaseResult,
                         "SearchAvailablePackages returned an unexpected set of packages");


### PR DESCRIPTION
`com.unity.entities` is no longer searchable from Unity 2020.