### PR TITLE
Update Test and Build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,9 +19,6 @@ on:
   schedule:
     - cron: "0 10 * * *"  # 10am UTC = 2am PST
 
-  pull_request:
-    types: [ labeled, closed ]
-
   workflow_dispatch:
     inputs:
       unity_version:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,31 @@ jobs:
             echo "include_test_modules=" >> $GITHUB_OUTPUT
             echo "exclude_test_modules=" >> $GITHUB_OUTPUT
             echo "exclude_tests=" >> $GITHUB_OUTPUT
+
+            if [[ "${{ github.event_name }}" == "schedule" ]]; then
+              # Do nothing for now
+            elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.label.name }}" == "tests-requested" ]]; then
+                # Do nothing for now
+              elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged == true}}" == "true"  ]]; then
+                # Do nothing for now
+              else
+                echo "invalid_trigger=1" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "invalid_trigger=1" >> $GITHUB_OUTPUT
+            fi
           fi
+
+      - name: Cancel workflow
+        if: ${{ steps.set_outputs.outputs.invalid_trigger }}
+        uses: andymckay/cancel-action@0.2
+
+      - name: Wait for workflow cancellation
+        if: ${{ steps.set_outputs.outputs.invalid_trigger }}
+        run: |
+          sleep 300
+          exit 1  # fail out if the cancellation above somehow failed.
 
       - name: Print output
         run: |
@@ -124,9 +148,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          cat test_output/test*/*_test.log | grep "^Test .* PASSED$"
-          cat test_output/test*/*_test.log | grep "^Test .* FAILED$"
-          cat test_output/test*/*_test.log | grep "^Test .* SKIPPED$"
+          cat test_output/test*/*_test.log | { grep "^Test .* FAILED$" || true; }
 
       - name: Return Unity license
         if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -153,8 +153,8 @@ jobs:
         run: |
           # Quick and dirty way to get all failed tests in granular level.
           # TODO: better parser for more information, ex. error message.
-          cat test_output/test*/*_test.log | { grep "^Test .* FAILED$" || true; }
-          cat test_output/test*/test*/results.xml | { grep '^ *<test-case.*result="Failed"' || true; } | sed 's/^.* name="\([^\"]*\)".*$/Test \1: FAILED/'
+          { cat test_output/test*/*_test.log || true; } | { grep "^Test .* FAILED$" || true; }
+          { cat test_output/test*/test*/results.xml || true; } | { grep '^ *<test-case.*result="Failed"' || true; } | sed 's/^.* name="\([^\"]*\)".*$/Test \1: FAILED/'
 
       - name: Return Unity license
         if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,11 +69,14 @@ jobs:
 
             if [[ "${{ github.event_name }}" == "schedule" ]]; then
               # Do nothing for now
+              :
             elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
               if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.label.name }}" == "tests-requested" ]]; then
                 # Do nothing for now
+                :
               elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged == true}}" == "true"  ]]; then
                 # Do nothing for now
+                :
               else
                 echo "invalid_trigger=1" >> $GITHUB_OUTPUT
               fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,7 @@ jobs:
             echo "exclude_test_modules=" >> $GITHUB_OUTPUT
             echo "exclude_tests=" >> $GITHUB_OUTPUT
 
+            # This is currently checking for invalid trigger only.
             if [[ "${{ github.event_name }}" == "schedule" ]]; then
               # Do nothing for now
               :

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,12 +143,15 @@ jobs:
         continue-on-error: true
         run: cat test_output/test*IntegrationTestsBatchMode/*.log
 
-      - name: Obtain Failed tests
+      - name: Obtain Failed tests from Integration tests and NUnit tests
         if: always()
         shell: bash
         continue-on-error: true
         run: |
+          # Quick and dirty way to get all failed tests in granular level.
+          # TODO: better parser for more information, ex. error message.
           cat test_output/test*/*_test.log | { grep "^Test .* FAILED$" || true; }
+          cat test_output/test*/test*/results.xml | { grep '^ *<test-case.*result="Failed"' || true; } | sed 's/^.* name="\([^\"]*\)".*$/Test \1: FAILED/'
 
       - name: Return Unity license
         if: always()


### PR DESCRIPTION
- Prevent unintended labels from triggering test workflow. Only `tests-requested` label would trigger test workflow now.
- Prevent pull request from triggering build workflows since test
  workflow would build EDM4U.
- Prevent test workflow from emitting error message just because
  `grep` command did not get any failed tests.
- Add info for failed NUnit tests