### PR TITLE
Fix project settings file getting corrupted

### DIFF
--- a/source/VersionHandlerImpl/src/ProjectSettings.cs
+++ b/source/VersionHandlerImpl/src/ProjectSettings.cs
@@ -257,8 +257,9 @@ namespace Google {
         {
             string stringValue = value.ToString();
 
-            if (!settings.ContainsKey(name) || settings[name] != stringValue) 
+            if (!settings.ContainsKey(name) || settings[name] != stringValue) {
                 IsModified = true;
+            }
             
             settings[name] = stringValue;
         }

--- a/source/VersionHandlerImpl/src/ProjectSettings.cs
+++ b/source/VersionHandlerImpl/src/ProjectSettings.cs
@@ -817,9 +817,10 @@ namespace Google {
                                       PROJECT_SETTINGS_FILE), LogLevel.Error);
                     return;
                 }
+                string tmpFile = Path.GetTempFileName();
                 try {
                     using (var writer =
-                           XmlWriter.Create(PROJECT_SETTINGS_FILE,
+                           XmlWriter.Create(tmpFile,
                                             new XmlWriterSettings {
                                                 Encoding = new UTF8Encoding(false),
                                                 Indent = true,
@@ -839,6 +840,8 @@ namespace Google {
                         }
                         writer.WriteEndElement();
                     }
+                    
+                    File.Copy(tmpFile, PROJECT_SETTINGS_FILE, true);
                 } catch (Exception exception) {
                     if (exception is IOException || exception is UnauthorizedAccessException) {
                         logger.Log(String.Format("Unable to write to '{0}' ({1}, " +
@@ -847,6 +850,10 @@ namespace Google {
                         return;
                     }
                     throw exception;
+                }
+                finally
+                {
+                    File.Delete(tmpFile);
                 }
             }
         }

--- a/source/VersionHandlerImpl/src/ProjectSettings.cs
+++ b/source/VersionHandlerImpl/src/ProjectSettings.cs
@@ -53,7 +53,7 @@ namespace Google {
     public interface ISettings {
         
         /// <summary>
-        /// Determine whether setting are out of sync and and to be persisted or not 
+        /// Determine whether setting are out of sync and needs to be persisted or not 
         /// </summary>
         bool IsModified { get; set; }
         
@@ -139,8 +139,8 @@ namespace Google {
     internal class EditorSettings : ISettings {
 
         /// <summary>
-        /// Determine whether setting are out of sync and and to be persisted or not
-        /// Always true as editor settings are always persisted by Unity
+        /// Determine whether setting are out of sync and needs to be persisted or not
+        /// Always false as editor settings are always persisted by Unity
         /// </summary>
         public bool IsModified { get { return false; } set { } }
         
@@ -239,7 +239,7 @@ namespace Google {
     internal class InMemorySettings : ISettings {
         
         /// <summary>
-        /// Determine whether setting are out of sync and and to be persisted or not
+        /// Determine whether setting are out of sync and needs to be persisted or not
         /// </summary>
         public bool IsModified { get; set; }
         
@@ -375,7 +375,7 @@ namespace Google {
     public class ProjectSettings : ISettings {
         
         /// <summary>
-        /// Determine whether setting are out of sync and and to be persisted or not
+        /// Determine whether setting are out of sync and needs to be persisted or not
         /// </summary>
         public bool IsModified
         {


### PR DESCRIPTION
# Why this change?
This resolve the settings file corruption as described in #524

Even though reading and writing of the settings file is protected by a lock, it is possible (due to _domain reload_) that 2 separate running processes are trying to access the file at the same time so the lock in one process is not aware of the other process.

A scenario like this could happen.
1. Code in domain A will start writing to ProjectsSettings file
2. Code in domain B will start reading the file
3. If domain A didn't finish writing yet, domain B will encounter unexpected EOF
4. Domain B will assume the file is broken and reset settings
5. Domain B will write default settings to ProjectsSettings file

# What did I do?
I made the writing happen to a temporary file. When the writing is complete, copy the temp file to the target path. This avoids the file being in an "invalid state" for a short time during the writing.

# Review
Feedback is greatly appreciated and please let me know which steps I need to take to make my change release-ready.