### PR TITLE
Add logic to automatically enable gradle templates in new projects

### DIFF
--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -18,6 +18,7 @@ namespace GooglePlayServices {
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Xml;

--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -1747,7 +1747,7 @@ namespace GooglePlayServices {
                     new ResolutionJob(
                         isAutoResolveJob,
                         () => {
-                            ResolveUnsafeAfterJetifierCheck(
+                            ResolveUnsafeAfterMainTemplateCheck(
                                 (success) => {
                                     SignalResolveJobComplete(() => {
                                             if (resolutionCompleteWithResult != null) {
@@ -1761,6 +1761,72 @@ namespace GooglePlayServices {
                         }));
             }
             if (firstJob) ExecuteNextResolveJob();
+        }
+
+        /// <summary>
+        /// Ensures that the mainTemplate.gradle and gradle.properties files are present in the project,
+        /// creating them via the Unity Editor's template files if needed.
+        /// </summary>
+        /// <returns>True if both files are present.</returns>
+        private static bool EnableGradleTemplates() {
+            return GradleTemplateResolver.EnsureGradleTemplateEnabled(GradleTemplateResolver.GradleTemplateFilename) &&
+            GradleTemplateResolver.EnsureGradleTemplateEnabled(GradleTemplateResolver.GradlePropertiesTemplateFilename);
+        }
+
+        /// <summary>
+        /// Resolve dependencies after checking if mainTemplate.gradle is enabled (or previously disabled).
+        /// </summary>
+        /// <param name="resolutionComplete">Delegate called when resolution is complete
+        /// with a parameter that indicates whether it succeeded or failed.</param>
+        /// <param name="forceResolution">Whether resolution should be executed when no dependencies
+        /// have changed.  This is useful if a dependency specifies a wildcard in the version
+        /// expression.</param>
+        /// <param name="isAutoResolveJob">Whether this is an auto-resolution job.</param>
+        /// <param name="closeWindowOnCompletion">Whether to unconditionally close the resolution
+        /// window when complete.</param>
+        private static void ResolveUnsafeAfterMainTemplateCheck(Action<bool> resolutionComplete,
+                                                                bool forceResolution,
+                                                                bool isAutoResolveJob,
+                                                                bool closeWindowOnCompletion) {
+            // If mainTemplate.gradle is already enabled, or if the user has rejected the switch,
+            // move to the next step.
+            if (GradleTemplateEnabled ||
+                SettingsDialogObj.UserRejectedGradleUpgrade) {
+                ResolveUnsafeAfterJetifierCheck(resolutionComplete, forceResolution, isAutoResolveJob, closeWindowOnCompletion);
+                return;
+            }
+            
+            // Else, if there are no resolved files tracked by this (aka, it hasn't been run before),
+            // turn on mainTemplate, and log a message to the user.
+            // Or, if using Batch mode, we want to enable the templates as well, since that is now the
+            // desired default behavior. If Users want to preserve the old method, they can save their
+            // SettingsObject with the UserRejectedGradleUpgrade option enabled.
+            if (ExecutionEnvironment.InBatchMode || !PlayServicesResolver.FindLabeledAssets().Any()) {
+                EnableGradleTemplates();
+                ResolveUnsafeAfterJetifierCheck(resolutionComplete, forceResolution, isAutoResolveJob, closeWindowOnCompletion);
+                return;
+            }
+
+            // Else, prompt the user to turn it on for them.
+            DialogWindow.Display(
+                "Enable Android Gradle templates?",
+                "Android Resolver recommends using Gradle templates " +
+                "for managing Android dependencies. The old method of downloading " +
+                "the dependencies into Plugins/Android is no longer recommended.",
+                DialogWindow.Option.Selected0, "Enable", "Disable",
+                complete: (selectedOption) => {
+                    switch (selectedOption) {
+                        case DialogWindow.Option.Selected0: // Enable
+                            EnableGradleTemplates();
+                            break;
+                        case DialogWindow.Option.Selected1: // Disable
+                            SettingsDialogObj.UserRejectedGradleUpgrade = true;
+                            break;
+                    }
+
+                    // Either way, proceed with the resolution.
+                    ResolveUnsafeAfterJetifierCheck(resolutionComplete, forceResolution, isAutoResolveJob, closeWindowOnCompletion);
+                });
         }
 
         /// <summary>

--- a/source/AndroidResolver/src/SettingsDialog.cs
+++ b/source/AndroidResolver/src/SettingsDialog.cs
@@ -48,6 +48,7 @@ namespace GooglePlayServices {
             internal bool autoResolutionDisabledWarning;
             internal bool promptBeforeAutoResolution;
             internal bool useProjectSettings;
+            internal bool userRejectedGradleUpgrade;
             internal EditorMeasurement.Settings analyticsSettings;
 
             /// <summary>
@@ -72,6 +73,7 @@ namespace GooglePlayServices {
                 autoResolutionDisabledWarning = SettingsDialog.AutoResolutionDisabledWarning;
                 promptBeforeAutoResolution = SettingsDialog.PromptBeforeAutoResolution;
                 useProjectSettings = SettingsDialog.UseProjectSettings;
+                userRejectedGradleUpgrade = SettingsDialog.UserRejectedGradleUpgrade;
                 analyticsSettings = new EditorMeasurement.Settings(PlayServicesResolver.analytics);
             }
 
@@ -97,6 +99,7 @@ namespace GooglePlayServices {
                 SettingsDialog.AutoResolutionDisabledWarning = autoResolutionDisabledWarning;
                 SettingsDialog.PromptBeforeAutoResolution = promptBeforeAutoResolution;
                 SettingsDialog.UseProjectSettings = useProjectSettings;
+                SettingsDialog.UserRejectedGradleUpgrade = userRejectedGradleUpgrade;
                 analyticsSettings.Save();
             }
         }
@@ -121,6 +124,7 @@ namespace GooglePlayServices {
         private const string PromptBeforeAutoResolutionKey =
             Namespace + "PromptBeforeAutoResolution";
         private const string UseGradleDaemonKey = Namespace + "UseGradleDaemon";
+        private const string UserRejectedGradleUpgradeKey = Namespace + "UserRejectedGradleUpgrade";
 
         // List of preference keys, used to restore default settings.
         private static string[] PreferenceKeys = new[] {
@@ -140,7 +144,8 @@ namespace GooglePlayServices {
             VerboseLoggingKey,
             AutoResolutionDisabledWarningKey,
             PromptBeforeAutoResolutionKey,
-            UseGradleDaemonKey
+            UseGradleDaemonKey,
+            UserRejectedGradleUpgradeKey
         };
 
         internal const string AndroidPluginsDir = "Assets/Plugins/Android";
@@ -291,6 +296,11 @@ namespace GooglePlayServices {
         internal static bool VerboseLogging {
             private set { projectSettings.SetBool(VerboseLoggingKey, value); }
             get { return projectSettings.GetBool(VerboseLoggingKey, false); }
+        }
+
+        internal static bool UserRejectedGradleUpgrade {
+            set { projectSettings.SetBool(UserRejectedGradleUpgradeKey, value); }
+            get { return projectSettings.GetBool(UserRejectedGradleUpgradeKey, false); }
         }
 
         internal static string ValidatePackageDir(string directory) {
@@ -508,6 +518,12 @@ namespace GooglePlayServices {
             }
 
             GUILayout.BeginHorizontal();
+            GUILayout.Label("Disable MainTemplate Gradle prompt", EditorStyles.boldLabel);
+            settings.userRejectedGradleUpgrade =
+                EditorGUILayout.Toggle(settings.userRejectedGradleUpgrade);
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
             GUILayout.Label("Patch mainTemplate.gradle", EditorStyles.boldLabel);
             settings.patchMainTemplateGradle =
                 EditorGUILayout.Toggle(settings.patchMainTemplateGradle);
@@ -697,7 +713,9 @@ namespace GooglePlayServices {
                         new KeyValuePair<string, string>(
                             "patchSettingsTemplateGradle",
                             SettingsDialog.PatchSettingsTemplateGradle.ToString()),
-
+                        new KeyValuePair<string, string>(
+                            "userRejectedGradleUpgrade",
+                            SettingsDialog.UserRejectedGradleUpgrade.ToString()),
                     },
                     "Settings Save");
 

--- a/source/AndroidResolver/test/src/AndroidResolverIntegrationTests.cs
+++ b/source/AndroidResolver/test/src/AndroidResolverIntegrationTests.cs
@@ -642,6 +642,8 @@ public class AndroidResolverIntegrationTests {
         GooglePlayServices.SettingsDialog.PatchPropertiesTemplateGradle = false;
         GooglePlayServices.SettingsDialog.PatchSettingsTemplateGradle = false;
 
+        GooglePlayServices.SettingsDialog.UserRejectedGradleUpgrade = true;
+
         PlayServicesSupport.ResetDependencies();
         UpdateAdditionalDependenciesFile(false, ADDITIONAL_DEPENDENCIES_FILENAME);
         UpdateAdditionalDependenciesFile(false, ADDITIONAL_DUPLICATE_DEPENDENCIES_FILENAME);


### PR DESCRIPTION
More dependencies, specifically Kotlin ones, will fail with the old resolution method.  We have encouraged users to use mainTemplate.gradle for several years now, so add logic such that for new projects will automatically enable it, and for projects that have already run the resolver before, a prompt window will appear asking them to do so first.  This prompt window checks against a new setting option, if users want to disable it.