### PR TITLE
Fix project settings resetting on domain reload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ project.ext {
     "MONO_EXE", false, {
       unityRootDirTree.matching {
         include (operatingSystem == OperatingSystem.WINDOWS ?
-          "**/bin/mono.exe" : "**/bin/mono")
+          "**/bin/mono.bat" : "**/bin/mono")
         exclude unitySearchDirExcludes
       }
     })
@@ -318,9 +318,9 @@ project.ext {
   pythonBootstrapDir = new File(externalToolsDir, "python_bootstrap")
   pythonBinDir = new File(new File(pythonBootstrapDir, "python"), "bin")
   // Python binary after it has been bootstrapped.
-  pythonExe = new File(new File(pythonBootstrapDir, "python"), "python")
+  pythonExe = new File(pythonBinDir, "python3")
   // Pip binary after it has been bootstrapped.
-  pipExe = new File(new File(new File(pythonBootstrapDir, "python"), "Scripts"), "pip3")
+  pipExe = new File(pythonBinDir, "pip3")
   // Python packages required by export_unity_package.py
   exportUnityPackageRequirements = ["absl-py", "PyYAML", "packaging"]
   // Python packages required by gen_guids.py

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ project.ext {
     "MONO_EXE", false, {
       unityRootDirTree.matching {
         include (operatingSystem == OperatingSystem.WINDOWS ?
-          "**/bin/mono.bat" : "**/bin/mono")
+          "**/bin/mono.exe" : "**/bin/mono")
         exclude unitySearchDirExcludes
       }
     })
@@ -318,9 +318,9 @@ project.ext {
   pythonBootstrapDir = new File(externalToolsDir, "python_bootstrap")
   pythonBinDir = new File(new File(pythonBootstrapDir, "python"), "bin")
   // Python binary after it has been bootstrapped.
-  pythonExe = new File(pythonBinDir, "python3")
+  pythonExe = new File(new File(pythonBootstrapDir, "python"), "python")
   // Pip binary after it has been bootstrapped.
-  pipExe = new File(pythonBinDir, "pip3")
+  pipExe = new File(new File(new File(pythonBootstrapDir, "python"), "Scripts"), "pip3")
   // Python packages required by export_unity_package.py
   exportUnityPackageRequirements = ["absl-py", "PyYAML", "packaging"]
   // Python packages required by gen_guids.py

--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -1043,8 +1043,7 @@ public class IOSResolver : AssetPostprocessor {
         }
     }
 
-    private static void UpdateLoggerLevel(bool verboseLoggingEnabled)
-    {
+    private static void UpdateLoggerLevel(bool verboseLoggingEnabled) {
         logger.Level = verboseLoggingEnabled ? LogLevel.Verbose : LogLevel.Info;
     }
 

--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -724,7 +724,7 @@ public class IOSResolver : AssetPostprocessor {
     /// </summary>
     static IOSResolver() {
         // Load log preferences.
-        VerboseLoggingEnabled = VerboseLoggingEnabled;
+        UpdateLoggerLevel(VerboseLoggingEnabled);
 
         // NOTE: We can't reference the UnityEditor.iOS.Xcode module in this
         // method as the Mono runtime in Unity 4 and below requires all
@@ -1039,8 +1039,13 @@ public class IOSResolver : AssetPostprocessor {
         get { return settings.GetBool(PREFERENCE_VERBOSE_LOGGING_ENABLED, defaultValue: false); }
         set {
             settings.SetBool(PREFERENCE_VERBOSE_LOGGING_ENABLED, value);
-            logger.Level = value ? LogLevel.Verbose : LogLevel.Info;
+            UpdateLoggerLevel(value);
         }
+    }
+
+    private static void UpdateLoggerLevel(bool verboseLoggingEnabled)
+    {
+        logger.Level = verboseLoggingEnabled ? LogLevel.Verbose : LogLevel.Info;
     }
 
     /// <summary>

--- a/source/PackageManagerResolver/src/PackageManagerResolver.cs
+++ b/source/PackageManagerResolver/src/PackageManagerResolver.cs
@@ -649,8 +649,7 @@ public class PackageManagerResolver : AssetPostprocessor {
         }
     }
     
-    private static void UpdateLoggerLevel(bool verboseLoggingEnabled)
-    {
+    private static void UpdateLoggerLevel(bool verboseLoggingEnabled) {
         logger.Level = verboseLoggingEnabled ? LogLevel.Verbose : LogLevel.Info;
     }
 

--- a/source/PackageManagerResolver/src/PackageManagerResolver.cs
+++ b/source/PackageManagerResolver/src/PackageManagerResolver.cs
@@ -94,7 +94,7 @@ public class PackageManagerResolver : AssetPostprocessor {
 
         RunOnMainThread.Run(() => {
                 // Load log preferences.
-                VerboseLoggingEnabled = VerboseLoggingEnabled;
+                UpdateLoggerLevel(VerboseLoggingEnabled);
             }, runNow: false);
     }
 
@@ -645,8 +645,13 @@ public class PackageManagerResolver : AssetPostprocessor {
         get { return settings.GetBool(PreferenceVerboseLoggingEnabled, defaultValue: false); }
         set {
             settings.SetBool(PreferenceVerboseLoggingEnabled, value);
-            logger.Level = value ? LogLevel.Verbose : LogLevel.Info;
+            UpdateLoggerLevel(value);
         }
+    }
+    
+    private static void UpdateLoggerLevel(bool verboseLoggingEnabled)
+    {
+        logger.Level = verboseLoggingEnabled ? LogLevel.Verbose : LogLevel.Info;
     }
 
     /// <summary>

--- a/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
+++ b/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
@@ -2290,7 +2290,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
     /// Load log preferences.
     /// </summary>
     private static void LoadLogPreferences() {
-        VerboseLoggingEnabled = VerboseLoggingEnabled;
+        UpdateLoggerLevel(VerboseLoggingEnabled);
     }
 
     /// <summary>
@@ -2512,8 +2512,13 @@ public class VersionHandlerImpl : AssetPostprocessor {
                                       defaultValue: false); }
         set {
             settings.SetBool(PREFERENCE_VERBOSE_LOGGING_ENABLED, value);
-            logger.Level = value ? LogLevel.Verbose : LogLevel.Info;
+            UpdateLoggerLevel(value);
         }
+    }
+    
+    private static void UpdateLoggerLevel(bool verboseLoggingEnabled)
+    {
+        logger.Level = verboseLoggingEnabled ? LogLevel.Verbose : LogLevel.Info;
     }
 
     /// <summary>

--- a/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
+++ b/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
@@ -2516,8 +2516,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         }
     }
     
-    private static void UpdateLoggerLevel(bool verboseLoggingEnabled)
-    {
+    private static void UpdateLoggerLevel(bool verboseLoggingEnabled) {
         logger.Level = verboseLoggingEnabled ? LogLevel.Verbose : LogLevel.Info;
     }
 


### PR DESCRIPTION
This resolves #524 by avoiding to needlessly save `GvhProjectSettings.xml` on every domain reload.

In all 3 modified files, the line
```
VerboseLoggingEnabled = VerboseLoggingEnabled;
```
does 3 things on domain reload because of `[InitializeOnLoad]`:
1. Loads `GvhProjectSettings.xml` if not already done
2. Writes `GvhProjectSettings.xml` unconditionally
3. Sets `logger.Level`

This PR removes step 2) which is unneeded and the cause of #524.

It's potentially possible that writing `GvhProjectSettings.xml` as a result of user interaction might still in some cases have a race condition. I didn't investigate this. However it's much less problematic than intermittent problems on domain reload.

# Why the problem happens
The current code is correctly protecting critical sections, including saving `GvhProjectSettings.xml`, with `lock (classLock)`. However a problem occurs with [parallel asset importing enabled in Unity](https://docs.unity3d.com/Manual/ParallelImport.html). In this case there are other Unity Editor processes aside from the "main" one that take care of parallel imports. These other processes each have their own separate instance of `classLock`.

This results in multiple processes reading and writing to `GvhProjectSettings.xml` on domain reload. Eventually one of them reads the file while it's being written and ends up with empty settings from `Google.ProjectSettings.Load` which it then re-saves. As the screenshot in #524 shows, when corruption happens it's always one or more `VerboseLoggingEnabled` that remain in the settings.

## About asset import worker processes
The command line of asset import worker processes looks like:
```
"C:\tools\Unity-Hub\2022.3.19f1\Editor\Unity.exe" "-adb2" "-batchMode" "-noUpm" "-name" "AssetImportWorker7" "-projectPath" "C:/dev/unity-project" "-logFile" "Logs/AssetImportWorker7.log" "-srvPort" "64205"
```
The `-adb2` argument is unique to asset import worker processes so could be used to identify them as needed.

# Build on Windows
Binaries here https://github.com/berniegp/unity-jar-resolver/releases/tag/v1.2.179

I could not build the plugin as it stands. The (reverted) commit ff03ffda690943f17800d3a26b97ba0d6e753c33 has the changes I needed to do to `build.gradle`.

As far as I can see, the build process [prefers Unity 5.6](https://github.com/googlesamples/unity-jar-resolver/blob/master/build.gradle#L163). This version (obviously) isn't supported on Apple Silicon so I tried on Windows.

Steps for successful build:
1. Install [Unity 5.6](https://unity.com/releases/editor/archive) with Android and iOS support
2. Start Unity 5.6 to sort out activation
3. Apply ff03ffda690943f17800d3a26b97ba0d6e753c33
4. Download and extract https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip to c:\tools
5. As administrator (so Python installs correctly, but pollutes add/remove programs) build with:
```
$env:JAVA_HOME='C:\tools\openjdk-11.0.2_windows-x64_bin\jdk-11.0.2\'; .\gradlew build -PUNITY_EXE=’<PATH_TO>\Unity-Hub\5.6.7f1\Editor\Unity.exe’; Remove-Item Env:\JAVA_HOME
```

Not sure if I'm doing something wrong regarding the build?