### PR TITLE
Update AssetDatabase.FindAssets usages return type

### DIFF
--- a/source/VersionHandler/src/VersionHandler.cs
+++ b/source/VersionHandler/src/VersionHandler.cs
@@ -153,7 +153,7 @@ public class VersionHandler {
         if (implAvailable) return;
 
         var assemblies = new List<Match>();
-        foreach (string assetGuid in AssetDatabase.FindAssets("l:gvh")) {
+        foreach (var assetGuid in AssetDatabase.FindAssets("l:gvh")) {
             string filename = AssetDatabase.GUIDToAssetPath(assetGuid);
             var match = VERSION_HANDLER_FILENAME_RE.Match(filename);
             if (match.Success) assemblies.Add(match);

--- a/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
+++ b/source/VersionHandlerImpl/src/VersionHandlerImpl.cs
@@ -2726,7 +2726,7 @@ public class VersionHandlerImpl : AssetPostprocessor {
         }
         var assetGuids = searchDirectories == null ? AssetDatabase.FindAssets(assetsFilter) :
             AssetDatabase.FindAssets(assetsFilter, searchDirectories);
-        foreach (string assetGuid in assetGuids) {
+        foreach (var assetGuid in assetGuids) {
             string filename = AssetDatabase.GUIDToAssetPath(assetGuid);
             // Ignore non-existent files as it's possible for the asset database to reference
             // missing files if it hasn't been refreshed or completed a refresh.


### PR DESCRIPTION
To ensure AssetDatabase.FindAssets works no matter what the return type is, the variables have been changed to type var instead of string.

Note: This is replicating the changes from https://github.com/googlesamples/unity-jar-resolver/pull/684, since they are having issues with the CLA.