### PR TITLE
Fix issues with copying Android files from Packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Upcoming
+* Android Resolver - Handle package paths that don't include a version hash,
+  which is no longer present with Unity 6. Fixes #697
+* Android Resolver - Handle packages referenced using local file paths.
+  Fixes 701
+
 # Version 1.2.182 - Aug 2, 2024
 * General - Check for gradle version instead of Unity version when determining
   the template files to modify.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Android Resolver - Handle package paths that don't include a version hash,
   which is no longer present with Unity 6. Fixes #697
 * Android Resolver - Handle packages referenced using local file paths.
-  Fixes 701
+  Fixes #701
 
 # Version 1.2.182 - Aug 2, 2024
 * General - Check for gradle version instead of Unity version when determining


### PR DESCRIPTION
Unity 6 no longer includes that `@version` part for the Packages in `Library/PackageCache/packageid@version`, so handle both cases.

When installing a UPM package from a local directory, https://docs.unity3d.com/Manual/upm-ui-local.html, it was failing to relocate any srcaar files to the generated folder as aars because the path was not as expected, so change it to search for the m2repository part of the path and do it based on that.

Fixes #697 and #701