### PR TITLE
chore: fix #412 #622 iOS resolver reference when iOS module not installed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch All builds
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: built_artifact
 

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -33,12 +33,12 @@ env:
 jobs:
   build_desktop:
     name: build-macOS-unity${{ inputs.unity_version}}
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: build_setup
         uses: ./gha/build_setup
@@ -89,7 +89,7 @@ jobs:
           fi
 
       - name: Upload build results artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: ${{ env.assetPackageArtifactName }}
@@ -97,7 +97,7 @@ jobs:
           retention-days: ${{ env.artifactRetentionDays }}
 
       - name: Upload build results artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: ${{ env.tarballPackageArtifactName }}

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -25,7 +25,7 @@ on:
         required: true
 
 env:
-  pythonVersion: '3.7'
+  pythonVersion: '3.9'
   artifactRetentionDays: 2
   assetPackageArtifactName: "AssetPackage_macOS"
   tarballPackageArtifactName: "TarballPackage_macOS"

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -25,7 +25,7 @@ on:
         required: true
 
 env:
-  pythonVersion: '3.9'
+  pythonVersion: '3.7'
   artifactRetentionDays: 2
   assetPackageArtifactName: "AssetPackage_macOS"
   tarballPackageArtifactName: "TarballPackage_macOS"
@@ -33,7 +33,7 @@ env:
 jobs:
   build_desktop:
     name: build-macOS-unity${{ inputs.unity_version}}
-    runs-on: macos-15
+    runs-on: macos-13
     strategy:
       fail-fast: false
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,12 +107,12 @@ jobs:
 
   test_on_macos:
     name: test-macOS-unity${{ needs.check_and_prepare.outputs.unity_version }}
-    runs-on: macos-13
+    runs-on: macos-15
     needs: [check_and_prepare]
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: build_setup
         uses: ./gha/build_setup
         timeout-minutes: 30
@@ -168,7 +168,7 @@ jobs:
           release_license: "true"
 
       - name: Upload build logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: logs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,7 +107,7 @@ jobs:
 
   test_on_macos:
     name: test-macOS-unity${{ needs.check_and_prepare.outputs.unity_version }}
-    runs-on: macos-15
+    runs-on: macos-13
     needs: [check_and_prepare]
     strategy:
       fail-fast: false

--- a/export_unity_package_config.json
+++ b/export_unity_package_config.json
@@ -49,7 +49,7 @@
             "gvhp_targets-editor"
           ],
           "paths": [
-            "ExternalDependencyManager/Editor/*/Google.IOSResolver.*",
+            "ExternalDependencyManager/Editor/*/Google.IOSResolver.*"
           ],
           "override_metadata_upm": {
             "PluginImporter": {

--- a/export_unity_package_config.json
+++ b/export_unity_package_config.json
@@ -5,7 +5,9 @@
       "imports": [
         {
           "importer": "PluginImporter",
-          "platforms": ["Editor"],
+          "platforms": [
+            "Editor"
+          ],
           "paths": [
             "ExternalDependencyManager/Editor/Google.VersionHandler.*"
           ]
@@ -13,21 +15,27 @@
         {
           "importer": "PluginImporter",
           "platforms": [],
-          "labels": ["gvhp_targets-editor"],
+          "labels": [
+            "gvhp_targets-editor"
+          ],
           "paths": [
-            "ExternalDependencyManager/Editor/*/Google.IOSResolver.*",
             "ExternalDependencyManager/Editor/*/Google.JarResolver.*",
             "ExternalDependencyManager/Editor/*/Google.VersionHandlerImpl.*",
             "ExternalDependencyManager/Editor/*/Google.PackageManagerResolver.*"
           ],
           "override_metadata_upm": {
             "PluginImporter": {
-              "platformData": [ {
-                  "first" : {
-                      "Editor": "Editor"
+              "defineConstraints": [
+                "UNITY_EDITOR",
+                "UNITY_IOS"
+              ],
+              "platformData": [
+                {
+                  "first": {
+                    "Editor": "Editor"
                   },
                   "second": {
-                      "enabled": 1
+                    "enabled": 1
                   }
                 }
               ]
@@ -35,7 +43,33 @@
           }
         },
         {
-          "sections": ["documentation"],
+          "importer": "PluginImporter",
+          "platforms": [],
+          "labels": [
+            "gvhp_targets-editor"
+          ],
+          "paths": [
+            "ExternalDependencyManager/Editor/*/Google.IOSResolver.*",
+          ],
+          "override_metadata_upm": {
+            "PluginImporter": {
+              "platformData": [
+                {
+                  "first": {
+                    "Editor": "Editor"
+                  },
+                  "second": {
+                    "enabled": 1
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sections": [
+            "documentation"
+          ],
           "importer": "DefaultImporter",
           "paths": [
             "ExternalDependencyManager/Editor/README.md",
@@ -50,21 +84,21 @@
           ]
         },
         {
-          "sections": ["unitypackage"],
+          "sections": [
+            "unitypackage"
+          ],
           "importer": "DefaultImporter",
           "paths": [
-              "PlayServicesResolver/Editor/play-services-resolver_v1.2.137.0.txt"
+            "PlayServicesResolver/Editor/play-services-resolver_v1.2.137.0.txt"
           ]
         }
       ],
       "manifest_path": "ExternalDependencyManager/Editor",
-
       "readme": "ExternalDependencyManager/Editor/README.md",
       "license": "ExternalDependencyManager/Editor/LICENSE",
       "changelog": "ExternalDependencyManager/Editor/CHANGELOG.md",
       "documentation": "ExternalDependencyManager/Editor/README.md",
-
-      "common_manifest" : {
+      "common_manifest": {
         "name": "com.google.external-dependency-manager",
         "display_name": "External Dependency Manager for Unity",
         "description": [
@@ -74,20 +108,24 @@
           "and/or management of Unity Package Manager registries."
         ],
         "keywords": [
-          "Google", "Android", "Gradle", "Cocoapods", "Dependency",
-          "Unity Package Manager", "Unity",
+          "Google",
+          "Android",
+          "Gradle",
+          "Cocoapods",
+          "Dependency",
+          "Unity Package Manager",
+          "Unity",
           "vh-name:play-services-resolver",
           "vh-name:unity-jar-resolver"
         ],
         "author": {
-          "name" : "Google LLC",
+          "name": "Google LLC",
           "url": "https://github.com/googlesamples/unity-jar-resolver"
         }
       },
-
-      "export_upm" : 1,
-      "upm_package_config" : {
-        "manifest" : {
+      "export_upm": 1,
+      "upm_package_config": {
+        "manifest": {
           "unity": "2019.1"
         }
       }

--- a/gha/build_setup/action.yml
+++ b/gha/build_setup/action.yml
@@ -42,7 +42,7 @@ runs:
   using: 'composite'
   steps:
     # Download GHA tools and requirements from Firebase Unity SDK repo
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: firebase/firebase-unity-sdk
         path: external/firebase-unity-sdk
@@ -51,7 +51,7 @@ runs:
         sparse-checkout-cone-mode: false
 
     - name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python_version }}
 

--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -1281,7 +1281,8 @@ class Asset(object):
       return importer_metadata
 
     platform_data = safe_dict_get_value(plugin_importer, "platformData",
-                                        default_value={})
+                                        default_value={},
+                                        value_classes=[dict, list])
     disable_platforms = sorted(set(platform_data).difference(
         set(supported_platforms)))
     # Disable the Any platform if any platforms are disabled.
@@ -1339,7 +1340,8 @@ class Asset(object):
 
     if serialized_version == 1:
       platform_data = safe_dict_get_value(plugin_importer, "platformData",
-                                          default_value={})
+                                          default_value={},
+                                          value_classes=[dict, list])
       for platform_name, options in platform_data.items():
         if not safe_dict_get_value(options, "enabled", default_value=0):
           continue
@@ -1353,7 +1355,8 @@ class Asset(object):
           options["settings"] = settings
     else:
       platform_data = safe_dict_get_value(plugin_importer, "platformData",
-                                          default_value=[])
+                                          default_value=[],
+                                          value_classes=[dict, list])
       for entry in platform_data:
         # Parse the platform name tuple from the "first" dictionary.
         first, second = Asset.platform_data_get_entry(entry)
@@ -1392,7 +1395,8 @@ class Asset(object):
 
     if serialized_version == 1:
       platform_data = safe_dict_get_value(plugin_importer, "platformData",
-                                          default_value={})
+                                          default_value={},
+                                          value_classes=[dict, list])
       for platform_name, options in platform_data.items():
         if not safe_dict_get_value(options, "enabled", default_value=0):
           continue
@@ -1404,7 +1408,8 @@ class Asset(object):
           options["settings"] = settings
     else:
       platform_data = safe_dict_get_value(plugin_importer, "platformData",
-                                          default_value=[])
+                                          default_value=[],
+                                          value_classes=[dict, list])
       for entry in platform_data:
         # Parse the platform name tuple from the "first" dictionary.
         first, second = Asset.platform_data_get_entry(entry)
@@ -1440,7 +1445,8 @@ class Asset(object):
 
     if serialized_version == 1:
       platform_data = safe_dict_get_value(plugin_importer, "platformData",
-                                          default_value={})
+                                          default_value={},
+                                          value_classes=[dict, list])
       # Check PluginImporter.platformData.Any.enabled for the Any platform
       # enabled in Unity 4 & early 5 metadata.
       any_enabled = platform_data.get("Any", {}).get("enabled", 0)
@@ -1459,7 +1465,8 @@ class Asset(object):
       # Search for the Any platform and retrieve if it's present and
       # enabled / disabled if Unity 5.4+ metadata.
       platform_data = safe_dict_get_value(plugin_importer, "platformData",
-                                          default_value=[])
+                                          default_value=[],
+                                          value_classes=[dict, list])
       any_enabled = 0
       for entry in platform_data:
         first, second = Asset.platform_data_get_entry(entry)
@@ -1870,7 +1877,9 @@ class AssetConfiguration(ConfigurationBlock):
             importer_metadata, cpu_string)
 
       # set define constraints
-      define_constraints = safe_dict_get_value(self._json, "defineConstraints", default_value=None)
+      define_constraints = safe_dict_get_value(self._json, "defineConstraints",
+                                               default_value=None,
+                                               value_classes=[dict, list])
       if define_constraints:
         importer_metadata["PluginImporter"]["defineConstraints"] = define_constraints
 

--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -1502,6 +1502,21 @@ class Asset(object):
       plugin_importer["platformData"] = new_platform_data
     return importer_metadata
 
+  @staticmethod
+  def set_define_constraints(importer_metadata):
+    """Set define constraints for the target platform.
+
+    Args:
+      importer_metadata: Metadata to modify. This is modified in-place.
+
+    Returns:
+      Modified importer_metadata.
+    """
+    define_constraints = safe_dict_get_value(importer_metadata, "PluginImporter", {}).get("defineConstraints")
+    if define_constraints:
+        importer_metadata["PluginImporter"]["defineConstraints"] = define_constraints
+    return importer_metadata
+
   @property
   def importer_metadata_original(self):
     """Get the original metadata section used to import this asset.
@@ -1548,6 +1563,7 @@ class Asset(object):
     metadata = Asset.disable_unsupported_platforms(metadata, self._filename)
     metadata = Asset.apply_any_platform_selection(metadata)
     metadata = Asset.set_cpu_for_desktop_platforms(metadata)
+    metadata = Asset.set_define_constraints(metadata)
     return metadata
 
   @staticmethod

--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -1851,6 +1851,12 @@ class AssetConfiguration(ConfigurationBlock):
       if "Android" in platforms and cpu_string != "AnyCPU":
         importer_metadata = Asset.set_cpu_for_android(
             importer_metadata, cpu_string)
+
+      # set define constraints
+      define_constraints = safe_dict_get_value(self._json, "defineConstraints", default_value=None)
+      if define_constraints:
+        importer_metadata["PluginImporter"]["defineConstraints"] = define_constraints
+
     else:
       raise ProjectConfigurationError(
           "Unknown importer type %s for package %s, paths %s" % (

--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -1512,7 +1512,8 @@ class Asset(object):
     Returns:
       Modified importer_metadata.
     """
-    define_constraints = safe_dict_get_value(importer_metadata, "PluginImporter", {}).get("defineConstraints")
+    plugin_importer = safe_dict_get_value(importer_metadata, "PluginImporter", default_value={})
+    define_constraints = plugin_importer.get("defineConstraints")
     if define_constraints:
         importer_metadata["PluginImporter"]["defineConstraints"] = define_constraints
     return importer_metadata

--- a/source/ExportUnityPackage/export_unity_package_test.py
+++ b/source/ExportUnityPackage/export_unity_package_test.py
@@ -2181,6 +2181,33 @@ class AssetConfigurationTest(absltest.TestCase):
                            "platforms": ["Standalone"],
                            "cpu": "x86_64"}).importer_metadata)
 
+  def test_importer_define_constraints(self):
+    """Test defineConstraints property."""
+    define_constraints = ["UNITY_EDITOR", "UNITY_IOS"]
+    self.plugin_metadata["PluginImporter"]["defineConstraints"] = define_constraints
+    self.assertEqual(
+        self.plugin_metadata,
+        export_unity_package.AssetConfiguration(
+            self.package, {
+                "importer": "PluginImporter",
+                "defineConstraints": define_constraints
+            }).importer_metadata)
+
+  def test_importer_define_constraints_upm(self):
+    """Test defineConstraints property for UPM."""
+    define_constraints = ["UNITY_EDITOR", "UNITY_IOS"]
+    self.plugin_metadata["PluginImporter"]["defineConstraints"] = define_constraints
+    self.assertEqual(
+        self.plugin_metadata,
+        export_unity_package.AssetConfiguration(
+            self.package, {
+                "importer": "PluginImporter",
+                "override_metadata_upm": {
+                    "PluginImporter": {
+                        "defineConstraints": define_constraints
+                    }
+                }
+            }).override_metadata_upm)
 
 class AssetPackageAndProjectFileOperationsTest(absltest.TestCase):
   """Tests for file operation methods."""


### PR DESCRIPTION
- fixes #412 
- fixes #622 
- updated `export_unity_package_config.json` and separated `Google.IOSResolver.*` into its own `PluginImporter` section, adding `defineConstraints` key with `UNITY_EDITOR` and `UNITY_IOS` elements.
- lint `export_unity_package_config.json` with standard json lint, 2 spaces
- added `defineConstraints` to `AssetConfiguration` in `export_unity_package.py`
- added unit tests for `defineConstraints` in `export_unity_package_test.py`
- updated workflows to use latest version of checkout/setup actions

### Fixes
```
Assembly 'Packages/com.google.external-dependency-manager/ExternalDependencyManager/Editor/1.2.183/Google.IOSResolver.dll' will not be loaded due to errors:
Unable to resolve reference 'UnityEditor.iOS.Extensions.Xcode'. Is the assembly missing or incompatible with the current platform?
Reference validation can be disabled in the Plugin Inspector.
```

# Invalid when platform is not set to IOS or module not installed
![image](https://github.com/user-attachments/assets/3d3d6db9-3620-4694-88d8-7c943defe93c)

# Valid when platform is set to IOS
![image](https://github.com/user-attachments/assets/24425be7-aaec-4049-8cc2-fa3133e46717)

CC @a-maurice, @chkuang-g
