### PR TITLE
Replace `packagingOptions` to `packaging` if AGP is 8.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Upcoming
+* Android Resolver - Update and resolve `packaging` keyword in maintemplate based on android gradle plugin version. Fixes #715
+
 # Version 1.2.183 - Sep 18, 2024
 * Android Resolver - Handle package paths that don't include a version hash,
   which is no longer present with Unity 6. Fixes #697

--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -2352,7 +2352,13 @@ namespace GooglePlayServices {
                     var sortedExcludeFiles = new List<string>(excludeFiles);
                     sortedExcludeFiles.Sort();
                     lines.Add("android {");
-                    lines.Add("  packagingOptions {");
+
+                    // `packagingOptions` is replaced by `packaging` keyword in Android Gradle plugin 8.0+
+                    if ((new Dependency.VersionComparer()).Compare("8.0", AndroidGradlePluginVersion) <= 0) {
+                        lines.Add("  packaging {");
+                    } else {
+                        lines.Add("  packagingOptions {");
+                    }
                     foreach (var filename in sortedExcludeFiles) {
                         // Unity's Android extension replaces ** in the template with an empty
                         // string presumably due to the token expansion it performs.  It's not


### PR DESCRIPTION
Fixes #715.

Due to incompatibility of the `packagingOptions` keyword in Unity 6, this will create unecessary `mainTemplate.gradle.backup`. Android keyword [Packaging](https://developer.android.com/reference/tools/gradle-api/8.0/com/android/build/api/dsl/Packaging) is introduced in Android Gradle Plugin version 8.0+.

Use `packaging` keyword if AGP version is 8.0+, else use `packagingOptions`

Unity version | Gradle version | Android Gradle Plug-in version
-- | -- | --
Unity-6 | 8.4 | 8.3.0
2022.3 | 7.5.1 | 7.4.2
2021.3 | 7.5.1 | 7.4.2


e.g.
```
// Android Resolver Exclusions Start
android {
  packaging {
      exclude ('/lib/arm64-v8a/*' + '*')
      exclude ('/lib/armeabi/*' + '*')
      exclude ('/lib/mips/*' + '*')
      exclude ('/lib/mips64/*' + '*')
      exclude ('/lib/x86/*' + '*')
      exclude ('/lib/x86_64/*' + '*')
  }
```