### PR TITLE
Reverse conditional checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Upcoming
+* Android Resolver - Reverse conditional checker for `packaging` keyword in maintemplate based on android gradle plugin version. Fixes #715
+
 # Version 1.2.184 - Jan 28, 2025
 * Android Resolver - Update and resolve `packaging` keyword in maintemplate
   based on android gradle plugin version.

--- a/source/AndroidResolver/src/PlayServicesResolver.cs
+++ b/source/AndroidResolver/src/PlayServicesResolver.cs
@@ -2354,7 +2354,7 @@ namespace GooglePlayServices {
                     lines.Add("android {");
 
                     // `packagingOptions` is replaced by `packaging` keyword in Android Gradle plugin 8.0+
-                    if ((new Dependency.VersionComparer()).Compare("8.0", AndroidGradlePluginVersion) <= 0) {
+                    if ((new Dependency.VersionComparer()).Compare("8.0", AndroidGradlePluginVersion) >= 0) {
                         lines.Add("  packaging {");
                     } else {
                         lines.Add("  packagingOptions {");


### PR DESCRIPTION
Incorrect conditional checker used on #718. Should use greater than or equal sign comparison.