### PR TITLE
Turn off validateReferences for the iOS Resolver

### DIFF
--- a/plugin/Assets/ExternalDependencyManager/Editor/Google.IOSResolver.dll.meta
+++ b/plugin/Assets/ExternalDependencyManager/Editor/Google.IOSResolver.dll.meta
@@ -12,6 +12,7 @@ PluginImporter:
   executionOrder: {}
   isPreloaded: 0
   isOverridable: 0
+  validateReferences: 0
   platformData:
   - first:
       Any: 

--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -1851,6 +1851,10 @@ class AssetConfiguration(ConfigurationBlock):
       if "Android" in platforms and cpu_string != "AnyCPU":
         importer_metadata = Asset.set_cpu_for_android(
             importer_metadata, cpu_string)
+      # Set validateReferences, if requested, which should be either 0 or 1
+      validateRef = safe_dict_get_value(self._json, "validateReferences", default_value=2)
+      if validateRef == 0 or validateRef == 1:
+        importer_metadata["PluginImporter"]["validateReferences"] = validateRef
     else:
       raise ProjectConfigurationError(
           "Unknown importer type %s for package %s, paths %s" % (

--- a/source/IOSResolver/src/IOSResolver.cs
+++ b/source/IOSResolver/src/IOSResolver.cs
@@ -843,9 +843,17 @@ public class IOSResolver : AssetPostprocessor {
     /// </summary>
     internal static bool MultipleXcodeTargetsSupported {
         get {
-            return typeof(UnityEditor.iOS.Xcode.PBXProject).GetMethod(
-                "GetUnityMainTargetGuid", Type.EmptyTypes) != null;
+            try {
+                return MultipleXcodeTargetsSupportedInternal();
+            } catch (Exception e) {
+                return false;
+            }
         }
+    }
+
+    private static bool MultipleXcodeTargetsSupportedInternal() {
+        return typeof(UnityEditor.iOS.Xcode.PBXProject).GetMethod(
+            "GetUnityMainTargetGuid", Type.EmptyTypes) != null;
     }
 
     /// <summary>
@@ -853,13 +861,21 @@ public class IOSResolver : AssetPostprocessor {
     /// </summary>
     public static string XcodeMainTargetName {
         get {
-            // NOTE: Unity-iPhone is hard coded in UnityEditor.iOS.Xcode.PBXProject and will no
-            // longer be exposed via GetUnityTargetName(). It hasn't changed in many years though
-            // so we'll use this constant as a relatively safe default.
-            return MultipleXcodeTargetsSupported ? "Unity-iPhone" :
-                (string)VersionHandler.InvokeStaticMethod(typeof(UnityEditor.iOS.Xcode.PBXProject),
-                                                          "GetUnityTargetName", null);
+            try {
+                return XcodeMainTargetNameInternal();
+            } catch (Exception e) {
+                return "Unity-iPhone";
+            }
         }
+    }
+
+    private static string XcodeMainTargetNameInternal() {
+        // NOTE: Unity-iPhone is hard coded in UnityEditor.iOS.Xcode.PBXProject and will no
+        // longer be exposed via GetUnityTargetName(). It hasn't changed in many years though
+        // so we'll use this constant as a relatively safe default.
+        return MultipleXcodeTargetsSupported ? "Unity-iPhone" :
+            (string)VersionHandler.InvokeStaticMethod(typeof(UnityEditor.iOS.Xcode.PBXProject),
+                                                    "GetUnityTargetName", null);
     }
 
     /// <summary>


### PR DESCRIPTION
By default, DLLs imported into Unity will validate all their references at load time. The iOS Resolver depends on the Unity iOS Support Library being present, which is not true by default for Windows developers. By turning off validateReferences, the library will no longer throw an exception at load time, but instead at runtime, which the library itself can handle instead.

https://github.com/googlesamples/unity-jar-resolver/issues/412
https://github.com/googlesamples/unity-jar-resolver/issues/622