### PR TITLE
Enable including samples in UPM packages

### DIFF
--- a/source/ExportUnityPackage/export_unity_package.py
+++ b/source/ExportUnityPackage/export_unity_package.py
@@ -2476,10 +2476,12 @@ class PackageConfiguration(ConfigurationBlock):
                         self.common_package_display_name)
       package_manifest["keywords"] = keywords
 
-    # Add minimum Unity version
+    # Add minimum Unity version, samples and dependencies.
     if self.upm_manifest:
       safe_dict_set_value(package_manifest, "unity",
                           safe_dict_get_value(self.upm_manifest, "unity"))
+      safe_dict_set_value(package_manifest, "samples",
+                          safe_dict_get_value(self.upm_manifest, "samples"))
       dependencies = safe_dict_get_value(
           self.upm_manifest, "dependencies", default_value={})
     else:


### PR DESCRIPTION
Unity allows custom UPM packages to add [samples](https://docs.unity3d.com/6000.1/Documentation/Manual/cus-samples.html). Adding support for the same.