### PR TITLE
Fix GradleMavenReposLinesFromDependencies()

### DIFF
--- a/source/AndroidResolver/src/GradleTemplateResolver.cs
+++ b/source/AndroidResolver/src/GradleTemplateResolver.cs
@@ -730,9 +730,12 @@ namespace GooglePlayServices {
                         // repo path contains .srcaar.
                         var repoPath = FileUtils.ReplaceBaseAssetsOrPackagesFolder(
                                 relativePath, GooglePlayServices.SettingsDialog.LocalMavenRepoDir);
-                        // We also want to just convert any prefixes before a directory/m2repository, since
-                        // they are copied to the LocalMavenRepoDir as well.
-                        repoPath = ReplaceLocalFolderBasedOnM2repo(repoPath);
+
+                        if (!repoPath.StartsWith(GooglePlayServices.SettingsDialog.LocalMavenRepoDir)) {
+                            // same replacement logic as in CopySrcAars() 
+                            repoPath = ReplaceLocalFolderBasedOnM2repo(repoPath);
+                        }
+                        
                         if (!Directory.Exists(repoPath)) {
                             repoPath = relativePath;
                         }


### PR DESCRIPTION
Fix GradleMavenReposLinesFromDependencies() for plugins and packages whose "m2repository" isn't a top level folder (a regression introduced in #709).

This should resolve #716, as described [here](https://github.com/googlesamples/unity-jar-resolver/issues/716#issuecomment-3472817062).