### PR TITLE
Minimal Performance Fix (for #601)

### DIFF
--- a/source/AndroidResolver/src/XmlDependencies.cs
+++ b/source/AndroidResolver/src/XmlDependencies.cs
@@ -33,7 +33,7 @@ namespace GooglePlayServices {
         /// specifications.
         /// </summary>
         internal HashSet<Regex> fileRegularExpressions = new HashSet<Regex> {
-            new Regex(@".*[/\\]Editor[/\\].*Dependencies\.xml$")
+            new Regex(@".*[/\\]Editor[/\\].*Dependencies\.xml$", RegexOptions.RightToLeft)
         };
 
         /// <summary>


### PR DESCRIPTION
Change the regular expression for dependency files to use `RegexOptions.RightToLeft`. This makes IOSResolver.OnPostprocessAllAssets() more than 100x faster, addressing issue #601.