### PR TITLE
Enable the editor dlls by default

### DIFF
--- a/plugin/Assets/ExternalDependencyManager/Editor/Google.IOSResolver.dll.meta
+++ b/plugin/Assets/ExternalDependencyManager/Editor/Google.IOSResolver.dll.meta
@@ -22,7 +22,7 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:

--- a/plugin/Assets/ExternalDependencyManager/Editor/Google.JarResolver.dll.meta
+++ b/plugin/Assets/ExternalDependencyManager/Editor/Google.JarResolver.dll.meta
@@ -21,7 +21,7 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:

--- a/plugin/Assets/ExternalDependencyManager/Editor/Google.PackageManagerResolver.dll.meta
+++ b/plugin/Assets/ExternalDependencyManager/Editor/Google.PackageManagerResolver.dll.meta
@@ -21,7 +21,7 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:

--- a/plugin/Assets/ExternalDependencyManager/Editor/Google.VersionHandlerImpl.dll.meta
+++ b/plugin/Assets/ExternalDependencyManager/Editor/Google.VersionHandlerImpl.dll.meta
@@ -21,7 +21,7 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:


### PR DESCRIPTION
The various editor DLLs should automatically be enabled for editor because of being in the Editor folder, but some users are having issues where it doesn't enable for some reason. Change the metadata so that it is enabled on Editor by default.